### PR TITLE
Optimize page changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ build/
 dist/
 *.spec
 !build_config.spec
+# Agent instructions (local only, not committed)
+AGENTS.md
+PR_PLAN_optimize_page.md

--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -25,6 +25,8 @@ from src.core.factors import Factor, FactorType, ChangeabilityLevel
 from src.core.coding import DesignSpace
 from src.core.analysis_base import (
     ANOVAResults,
+    build_anova_effect_summary,
+    build_coefficient_significance,
     enforce_hierarchy,
     parse_model_term,
     quadratic,
@@ -448,6 +450,20 @@ class ANOVAAnalysis:
             else:
                 logworth_values.append(-np.log10(p))
         logworth_df['LogWorth'] = logworth_values
+
+        # Canonical effect tables.  ``coefficient_significance`` keeps the
+        # fitted-model coefficient tests; ``anova_effect_summary`` is sourced
+        # from the displayed ANOVA table.  The two are deliberately distinct.
+        block_names = ('Block',) if (
+            self.design_structure.get('has_blocking')
+            and not self.block_as_random
+        ) else ()
+        coefficient_significance = build_coefficient_significance(
+            effect_estimates, anova_table, block_factor_names=block_names
+        )
+        anova_effect_summary = build_anova_effect_summary(
+            anova_table, effect_estimates, block_factor_names=block_names
+        )
         
         return ANOVAResults(
             anova_table=anova_table,
@@ -461,7 +477,9 @@ class ANOVAAnalysis:
             is_split_plot=is_split_plot,
             r_squared=r_squared,
             adj_r_squared=adj_r_squared,
-            rmse=rmse
+            rmse=rmse,
+            coefficient_significance=coefficient_significance,
+            anova_effect_summary=anova_effect_summary,
         )
     
     def _compute_diagnostics(self, residuals: np.ndarray, fitted_values: np.ndarray) -> Dict:

--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -13,6 +13,7 @@ quadratic) live in ``analysis_base`` to avoid circular imports with
 """
 
 import warnings
+import re
 from typing import List, Dict, Optional, Union, Literal, Tuple
 import numpy as np
 import pandas as pd
@@ -346,14 +347,54 @@ class ANOVAAnalysis:
     
     def _build_formula(self, model_terms: List[str]) -> str:
         """Build formula - terms already in patsy notation."""
-        terms = [t for t in model_terms if t != '1']
+        terms = [t for t in self._wrap_categorical_terms(model_terms) if t != '1']
         if not terms:
             # Intercept-only model
             formula_rhs = '1'
         else:
             formula_rhs = ' + '.join(terms)
         return f"{self.response_name} ~ {formula_rhs}"
+
+    def _wrap_categorical_terms(self, model_terms: List[str]) -> List[str]:
+        """
+        Wrap categorical factor names in patsy ``C(...)`` so they are always
+        treated as categorical, regardless of the data column dtype.
+
+        Without this, a categorical factor whose levels are numeric-looking
+        labels (e.g. lot/batch IDs) can be silently fitted as a continuous
+        predictor: patsy decides categorical-vs-continuous purely from the
+        column dtype, and ``float64`` columns get a single linear coefficient
+        (DF=1) instead of k-1 dummy columns.
+        """
+        categorical = {f.name for f in self.factors if f.is_categorical()}
+        if not categorical:
+            return list(model_terms)
+
+        wrapped_terms = []
+        for term in model_terms:
+            if term == '1':
+                wrapped_terms.append(term)
+                continue
+            new_term = term
+            for name in sorted(categorical, key=len, reverse=True):
+                if re.search(r'C\(' + re.escape(name) + r'\)', new_term):
+                    continue
+                pattern = r'(?<![\w)])' + re.escape(name) + r'(?![\w])'
+                new_term = re.sub(pattern, f'C({name})', new_term)
+            wrapped_terms.append(new_term)
+        return wrapped_terms
     
+    @staticmethod
+    def _strip_c_wrappers(label: str) -> str:
+        """
+        Remove patsy ``C(...)`` wrappers from a term label so results are
+        reported using plain factor names, e.g.:
+          ``C(Egg_lot)`` -> ``Egg_lot``
+          ``C(Egg_lot)[T.41007666]`` -> ``Egg_lot[T.41007666]``
+          ``C(Egg_lot):Egg_percent`` -> ``Egg_lot:Egg_percent``
+        """
+        return re.sub(r'C\(([^()]*)\)', r'\1', label)
+
     def _build_results_object(self, fitted_model, model_terms: List[str], is_split_plot: bool) -> ANOVAResults:
         """Build results from fitted model."""
         try:
@@ -365,12 +406,21 @@ class ANOVAAnalysis:
             warnings.warn(f"Could not compute ANOVA: {e}")
             anova_table = pd.DataFrame()
         
+        if not anova_table.empty:
+            anova_table = anova_table.copy()
+            anova_table.index = [
+                self._strip_c_wrappers(str(i)) for i in anova_table.index
+            ]
+        
         effect_estimates = pd.DataFrame({
             'Coefficient': fitted_model.params,
             'Std_Error': fitted_model.bse,
             't_value': fitted_model.tvalues,
             'p_value': fitted_model.pvalues
         })
+        effect_estimates.index = [
+            self._strip_c_wrappers(str(i)) for i in effect_estimates.index
+        ]
         residuals = fitted_model.resid
         fitted_values = fitted_model.fittedvalues
         
@@ -425,7 +475,7 @@ class ANOVAAnalysis:
     def _validate_degrees_of_freedom(self, model_terms: List[str]) -> None:
         """Validate DF and warn about saturation."""
         n_runs = len(self.data)
-        n_params = len([t for t in model_terms if t != '1']) + 1
+        n_params = 1 + self._estimate_n_parameters(model_terms)
         df_error = n_runs - n_params
 
         if df_error < 0:
@@ -440,6 +490,40 @@ class ANOVAAnalysis:
             )
         elif df_error < 3:
             warnings.warn(f"Low df_error = {df_error}: Inference may be unreliable")
+
+    def _estimate_n_parameters(self, model_terms: List[str]) -> int:
+        """
+        Estimate the number of model parameters consumed by each term,
+        counting categorical dummy expansion.
+
+        A categorical main effect with k levels is fit as ``k-1`` dummy
+        columns; an interaction ``A*B`` consumes ``df_A * df_B`` columns, where
+        ``df`` of a categorical factor is ``k-1`` and ``1`` otherwise.
+        """
+        factor_df: Dict[str, int] = {}
+        for factor in self.factors:
+            if factor.is_categorical():
+                n_levels = len(factor.levels)
+                if n_levels < 2:
+                    n_levels = self.data[factor.name].nunique()
+                factor_df[factor.name] = max(n_levels - 1, 0)
+            else:
+                factor_df[factor.name] = 1
+
+        total = 0
+        for term in model_terms:
+            if term == '1':
+                continue
+            factor_list, op = parse_model_term(term)
+            if op == '*':
+                dfs = [factor_df.get(name, 1) for name in factor_list]
+                if not dfs or any(df <= 0 for df in dfs):
+                    continue
+                total += int(np.prod(dfs))
+            else:
+                name = factor_list[0] if factor_list else ''
+                total += factor_df.get(name, 1)
+        return total
 
     def _validate_split_plot_degrees_of_freedom(self) -> None:
         """Warn when the whole-plot stratum has too few groups for reliable inference."""

--- a/src/core/analysis_base.py
+++ b/src/core/analysis_base.py
@@ -146,16 +146,14 @@ class ANOVAResults:
                     prediction += float(coefficients[coef_key]) * val ** 2
 
             elif operator == "*":
-                # Two-way interaction (A*B -> patsy stores as A:B)
-                vals = [float(settings.get(f, 0)) for f in factor_list]  # type: ignore[arg-type]
-                product = vals[0] * vals[1]
-                coef_key = next(
-                    (k for k in coefficients.index
-                     if k == term or k == term.replace("*", ":")),
-                    None,
+                # Two-way interaction (A*B -> patsy stores as A:B).
+                # Continuous factors enter as scalar * value; categorical
+                # factors match their dummy key F[T.level]. patsy expands a
+                # categorical interaction into dummies with the all-reference
+                # baseline suppressed.
+                prediction += self._predict_interaction(
+                    factor_list, term, settings, coefficients
                 )
-                if coef_key is not None:
-                    prediction += float(coefficients[coef_key]) * product
 
             else:
                 # Main effect - continuous or categorical
@@ -175,6 +173,70 @@ class ANOVAResults:
                     # Reference level contributes 0 (absorbed in intercept)
 
         return prediction
+
+    def _predict_interaction(
+        self,
+        factor_list: List[str],
+        term: str,
+        settings: Dict[str, object],
+        coefficients: pd.Series,
+    ) -> float:
+        """
+        Predict the contribution of a two-way interaction term.
+
+        Handles continuous/continuous (single ``A:B`` coefficient) as well as
+        categorical interactions (patsy expands into ``C(A)[T.x]:C(B)[T.y]``
+        dummies with the all-reference baseline suppressed; the plain ``A:B``
+        key corresponds to a categorical main effect evaluated at its
+        reference level in the other dimension).
+
+        Each factor in the interaction is matched against the levels in
+        ``settings``.  Continuous factors are treated as scalar variables; a
+        match is required for categorical ones.
+        """
+        total = 0.0
+        f1, f2 = factor_list
+        v1 = settings.get(f1, 0)
+        v2 = settings.get(f2, 0)
+
+        # Classify each side as continuous (scalar) or categorical (has
+        # dummy keys of the form F[T.level] in the coefficient index).
+        def is_categorical(name: str) -> bool:
+            cat_level_key = f"{name}[T."
+            return any(
+                str(k).startswith(cat_level_key)
+                for k in coefficients.index
+            )
+
+        cat1 = is_categorical(f1)
+        cat2 = is_categorical(f2)
+
+        if not cat1 and not cat2:
+            # Both continuous: single coefficient A:B
+            coef_key = next(
+                (k for k in coefficients.index
+                 if k == term or k == term.replace("*", ":")),
+                None,
+            )
+            if coef_key is not None:
+                return float(coefficients[coef_key]) * float(v1) * float(v2)
+            return 0.0
+
+        # At least one categorical. Build the exact patsy interaction key(s)
+        # for the selected levels and sum the matching coefficients.
+        #   categorical-only : A[T.x]:B[T.y]   (order matches term)
+        #   mixed            : A[T.x]:B  or  A:B[T.y]
+        def side_key(name: str, val: object, cat: bool) -> str:
+            return f"{name}[T.{val}]" if cat else name
+
+        k1 = side_key(f1, v1, cat1)
+        k2 = side_key(f2, v2, cat2)
+
+        candidates = {f"{k1}:{k2}", f"{k2}:{k1}"}
+        for k in coefficients.index:
+            if str(k) in candidates:
+                total += float(coefficients[k])
+        return total
 
 
 # ---------------------------------------------------------------------------
@@ -350,13 +412,31 @@ def parse_model_term(term: str) -> Tuple[List[str], str]:
     # misclassifying np.log(A)*B as an interaction)                      #
     # ------------------------------------------------------------------ #
     if '*' in term:
-        factor_list = [f.strip() for f in term.split('*')]
+        factor_list = [_unwrap_c(seg) for seg in term.split('*')]
         return factor_list, '*'
 
     # ------------------------------------------------------------------ #
-    # Plain main effect: A                                                #
+    # Plain main effect: A (or C(A) for categorical factors)              #
     # ------------------------------------------------------------------ #
-    return [term.strip()], ''
+    return [_unwrap_c(term.strip())], ''
+
+
+def _unwrap_c(segment: str) -> str:
+    """
+    Strip a patsy ``C(...)`` wrapper from a factor segment so its underlying
+    factor name can be found in the factor registry.
+
+    Examples
+    --------
+    >>> _unwrap_c('C(Egg_lot)')
+    'Egg_lot'
+    >>> _unwrap_c('Egg_lot')
+    'Egg_lot'
+    """
+    segment = segment.strip()
+    if segment.startswith('C(') and segment.endswith(')'):
+        return segment[2:-1].strip()
+    return segment
 
 
 # ---------------------------------------------------------------------------

--- a/src/core/analysis_base.py
+++ b/src/core/analysis_base.py
@@ -17,12 +17,16 @@ Contents
 
 from __future__ import annotations
 
+import re
 import warnings
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+from scipy import stats
+
+from src.core.factors import Factor
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +68,12 @@ class ANOVAResults:
         Adjusted R².
     rmse : float
         Root mean squared error of residuals.
+    coefficient_significance : Optional[pd.DataFrame]
+        Coefficient-level significance table (one row per fitted coefficient,
+        p-values from :attr:`fitted_model.pvalues`).
+    anova_effect_summary : Optional[pd.DataFrame]
+        Term-level ANOVA effect summary (one row per ANOVA term, p-values and
+        F-statistics sourced from :attr:`anova_table`).
     """
 
     anova_table: pd.DataFrame
@@ -78,6 +88,8 @@ class ANOVAResults:
     r_squared: float
     adj_r_squared: float
     rmse: float
+    coefficient_significance: Optional[pd.DataFrame] = None
+    anova_effect_summary: Optional[pd.DataFrame] = None
 
     def predict_from_settings(self, settings: Dict[str, object]) -> float:
         """
@@ -437,6 +449,554 @@ def _unwrap_c(segment: str) -> str:
     if segment.startswith('C(') and segment.endswith(')'):
         return segment[2:-1].strip()
     return segment
+
+
+# ---------------------------------------------------------------------------
+# Coefficient-to-term matching and effect summary builders
+#
+# These helpers live here so that both the fixed-effects path
+# (``src.core.analysis``) and the split-plot path
+# (``src.core.split_plot_analysis``) share the same term-matching logic and
+# construct the same canonical dataframes.
+#
+# Two deliberately separate tables are produced:
+#   * ``build_coefficient_significance`` — one row per fitted COEFFICIENT,
+#     p-values kept from ``fitted_model.pvalues``.
+#   * ``build_anova_effect_summary`` — one row per term-level ANOVA test,
+#     p-values and F-statistics kept from the displayed ANOVA table.
+# The mapping between the two never replaces one statistic with the other.
+# ---------------------------------------------------------------------------
+
+
+#: Centralised policy: fixed Block terms are excluded from the Bonferroni
+#: multiplicity family (``m``).  The family is intended for experimental
+#: effects, not design/nuisance terms.
+BONFERRONI_EXCLUDE_BLOCK = True
+
+
+def _strip_all_c_wrappers(label: str) -> str:
+    """Remove every patsy ``C(...)`` wrapper from a label.
+
+    Examples
+    --------
+    ``C(Egg_lot)[T.41007666]`` -> ``Egg_lot[T.41007666]``
+    """
+    return re.sub(r'C\(([^()]*)\)', r'\1', str(label))
+
+
+def _normalize_term(term) -> str:
+    """Collapse a term label to a canonical string for comparisons."""
+    return re.sub(r'\s+', '', _strip_all_c_wrappers(str(term)))
+
+
+def _term_factor_segments(term) -> List[str]:
+    """
+    Extract the ordered factor segments of a term, dropping categorical dummy
+    encodings (``Factor[T.Level]``) and interaction separators.
+    """
+    t = _normalize_term(term)
+    t = re.sub(r'\[T\..*?\]', '', t)
+    t = t.replace('*', ':')
+    m = re.match(r'I\((.+?)\s*\*\*\s*2\)', t)
+    if m:
+        return [m.group(1).strip()]
+    return [s.strip() for s in t.split(':') if s.strip()]
+
+
+def _term_sort_key(term):
+    """Order-independent key for a term (``A:B`` == ``B:A``)."""
+    return tuple(sorted(_term_factor_segments(term)))
+
+
+def _classify_term_type(term) -> str:
+    """Classify a term as main / interaction / quadratic / other."""
+    t = re.sub(r'\[T\..*?\]', '', _normalize_term(term))
+    if re.match(r'^I\(.+\)$', t):
+        return 'quadratic'
+    segs = [s for s in t.replace('*', ':').split(':') if s]
+    if len(segs) > 1:
+        return 'interaction'
+    return 'main'
+
+
+def _is_block_term(term, block_factor_names: Tuple[str, ...] = ('Block',)) -> bool:
+    """True when *term* involves one of the design/block factor names."""
+    for seg in _term_factor_segments(term):
+        if seg in block_factor_names:
+            return True
+    return False
+
+
+# Rows in an ANOVA table that never represent experimental effects.
+NON_EFFECT_ANOVA_ROWS = frozenset({
+    'Intercept', 'const', 'Residual', 'WholePlot Error', 'SubPlot Error',
+    'Whole Plot Error', 'Sub Plot Error', 'Pure Error', 'Lack of Fit',
+    'Cor Total', 'Model',
+})
+
+
+def _is_non_effect_row(term) -> bool:
+    if term in NON_EFFECT_ANOVA_ROWS:
+        return True
+    low = str(term).lower().replace(' ', '')
+    return low in {'intercept', 'residual', 'wholeplaterror', 'subplaterror',
+                   'pureerror', 'lackoffit', 'cortotal', 'model'}
+
+
+def _safe_float(value) -> Optional[float]:
+    try:
+        f = float(value)
+        return None if np.isnan(f) else f
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def coefficient_logworth(p) -> float:
+    """
+    LogWorth for a p-value with safe handling of underflow.
+
+    ``p <= 0`` / NaN yields NaN.  Otherwise ``-log10(max(p, tiny))``.
+    """
+    if p is None:
+        return np.nan
+    try:
+        p = float(p)
+    except (TypeError, ValueError):
+        return np.nan
+    if not np.isfinite(p) or p <= 0:
+        return np.nan
+    p_safe = max(p, np.finfo(float).tiny)
+    return -np.log10(p_safe)
+
+
+def find_effect_estimate_key(source: str, index: pd.Index) -> Optional[str]:
+    """
+    Map an ANOVA term / coefficient label back to a coefficient table index.
+
+    Handles patsy/statsmodels conventions:
+    - direct matches (``'Temperature'``)
+    - ``'*'`` vs ``':'`` interaction separators
+    - interaction-order normalisation (``'A:B'`` == ``'B:A'``)
+    - categorical dummies (``'Atmosphere'`` -> ``'Atmosphere[T.nitrogen]'`` or
+      ``'C(Atmosphere)[T.air]'``)
+    - nested/institution interaction dummies
+      (``'Temperature:Atmosphere'`` -> ``'Temperature:Atmosphere[T.nitrogen]'``)
+
+    Returns
+    -------
+    The matching index key, or ``None`` when no safe match exists.
+    """
+    index = list(index)
+    if source in index:
+        return source
+    patsy_form = str(source).replace('*', ':')
+    if patsy_form in index:
+        return patsy_form
+
+    src_key = _term_sort_key(source)
+    for key in index:
+        if _term_sort_key(key) == src_key:
+            return key
+
+    base = _strip_all_c_wrappers(patsy_form)
+    for key in index:
+        if key.startswith(base) or key.startswith(patsy_form):
+            return key
+    return None
+
+
+def find_parent_anova_term(coef_name: str, anova_terms) -> Optional[str]:
+    """
+    Map a fitted coefficient label to its parent ANOVA term.
+
+    Used for labelling / effect-sign recovery only.  Never replaces the
+    coefficient's own p-value with the parent term's ANOVA p-value.
+    """
+    anova_terms = list(anova_terms)
+    if coef_name in anova_terms:
+        return coef_name
+    patsy_form = str(coef_name).replace('*', ':')
+    if patsy_form in anova_terms:
+        return patsy_form
+
+    coef_key = _term_sort_key(coef_name)
+    for term in anova_terms:
+        if _term_sort_key(term) == coef_key:
+            return term
+
+    base = _normalize_term(coef_name)
+    base = re.sub(r'\[T\..*?\]', '', base).replace('*', ':')
+    for term in anova_terms:
+        if _normalize_term(term) == base:
+            return term
+    return None
+
+
+def attach_critical_limits(
+    summary: pd.DataFrame,
+    alpha: float = 0.05,
+) -> pd.DataFrame:
+    """
+    (Re)compute per-term ``t_critical`` and ``bonferroni_limit`` columns.
+
+    Residual degrees of freedom are taken per-term from ``residual_df`` so the
+    limits are correct for multi-strata (split-plot) models where different
+    terms use different error strata.
+
+    ``m`` (the Bonferroni multiplicity family size) is the number of eligible
+    experimental effects in *summary*.  Per :data:`BONFERRONI_EXCLUDE_BLOCK`,
+    fixed Block terms are excluded from ``m`` by default.  Callers should call
+    this again after filtering (e.g. hiding Block) so the limits track the
+    displayed effect set.
+    """
+    if summary is None or summary.empty:
+        return summary
+    df = summary.copy()
+    if BONFERRONI_EXCLUDE_BLOCK:
+        m = int(np.sum(~df['is_block'].astype(bool)))
+    else:
+        m = int(len(df))
+    m = max(m, 1)
+
+    t_crits, bonfs = [], []
+    for _, row in df.iterrows():
+        rd = row.get('residual_df', np.nan)
+        if rd is None:
+            t_crits.append(np.nan)
+            bonfs.append(np.nan)
+            continue
+        try:
+            rd = float(rd)
+        except (TypeError, ValueError):
+            t_crits.append(np.nan)
+            bonfs.append(np.nan)
+            continue
+        if not np.isfinite(rd) or rd <= 0:
+            t_crits.append(np.nan)
+            bonfs.append(np.nan)
+            continue
+        tc = stats.t.ppf(1 - alpha / 2, rd)
+        bc = stats.t.ppf(1 - alpha / (2 * m), rd)
+        t_crits.append(tc)
+        bonfs.append(bc)
+    df['t_critical'] = t_crits
+    df['bonferroni_limit'] = bonfs
+    return df
+
+
+def build_anova_effect_summary(
+    anova_table: Optional[pd.DataFrame],
+    effect_estimates: Optional[pd.DataFrame] = None,
+    block_factor_names: Tuple[str, ...] = ('Block',),
+    alpha: float = 0.05,
+) -> pd.DataFrame:
+    """
+    Build the canonical term-level ANOVA effect summary.
+
+    Source of truth: the displayed :attr:`anova_table` (``PR(>F)`` for
+    fixed-effects statsmodels tables, ``P`` for split-plot tables).  One row
+    per eligible ANOVA term (intercept/residual/error rows excluded).
+
+    Standardized statistic:
+    - ``df == 1``: ``sign(effect_estimate) * sqrt(F)`` (``|t| = sqrt(F)``),
+      with sign recovered from the matched coefficient when available.
+    - ``df > 1``: ``sqrt(F)`` labelled ``omnibus sqrt(F)``; multi-DF terms do
+      NOT have a single coefficient t-statistic and are never assigned a sign.
+    """
+    if anova_table is None or anova_table.empty:
+        return pd.DataFrame()
+
+    p_col = ('PR(>F)' if 'PR(>F)' in anova_table.columns
+             else 'P' if 'P' in anova_table.columns else None)
+    has_stratum = 'Stratum' in anova_table.columns
+    ss_col = 'sum_sq' if 'sum_sq' in anova_table.columns else 'SS'
+
+    def residual_df_for(stratum) -> Optional[float]:
+        if not has_stratum:
+            if 'Residual' in anova_table.index:
+                return _safe_float(anova_table.loc['Residual', 'df'])
+            return None
+        err_row = ('WholePlot Error' if stratum == 'Whole-Plot'
+                   else 'SubPlot Error')
+        if err_row in anova_table.index:
+            return _safe_float(anova_table.loc[err_row, 'df'])
+        return None
+
+    coef_index = effect_estimates.index if effect_estimates is not None else None
+
+    rows = []
+    for term, row in anova_table.iterrows():
+        if _is_non_effect_row(term):
+            continue
+
+        df = _safe_int(row.get('df'))
+        F = _safe_float(row.get('F'))
+        p = _safe_float(row.get(p_col)) if p_col else None
+        stratum = row.get('Stratum') if has_stratum else None
+        residual_df = residual_df_for(stratum)
+
+        effect_estimate = np.nan
+        effect_sign = np.nan
+        standardized = np.nan
+        stat_type = 'sqrt(F) not applicable'
+        if df is not None and F is not None and F >= 0:
+            if df == 1:
+                key = None
+                if coef_index is not None and len(coef_index):
+                    key = find_effect_estimate_key(term, coef_index)
+                if key is not None:
+                    try:
+                        coeff = float(effect_estimates.loc[key, 'Coefficient'])
+                    except (KeyError, TypeError, ValueError):
+                        coeff = np.nan
+                    if np.isfinite(coeff):
+                        effect_estimate = coeff
+                        effect_sign = np.sign(coeff)
+                standardized = np.sqrt(float(F))
+                if effect_sign is not None and np.isfinite(effect_sign):
+                    standardized = effect_sign * standardized
+                stat_type = '|t| = sqrt(F)'
+            elif df > 1:
+                standardized = np.sqrt(float(F))
+                stat_type = 'omnibus sqrt(F)'
+        elif df is None or F is None:
+            stat_type = 'unavailable'
+
+        rows.append({
+            'term': term,
+            'normalized_term': _normalize_term(term),
+            'term_type': _classify_term_type(term),
+            'sum_sq': _safe_float(row.get(ss_col)),
+            'df': df,
+            'F': F,
+            'p_value': p,
+            'effect_estimate': effect_estimate,
+            'effect_sign': effect_sign,
+            'standardized_statistic': standardized,
+            'standardized_statistic_type': stat_type,
+            'residual_df': residual_df,
+            'is_block': _is_block_term(term, block_factor_names),
+            'source': 'displayed term-level ANOVA table',
+        })
+
+    summary = pd.DataFrame(rows)
+    if not summary.empty:
+        summary = summary.set_index('term', drop=False)
+        summary = attach_critical_limits(summary, alpha=alpha)
+    return summary
+
+
+def build_coefficient_significance(
+    effect_estimates: Optional[pd.DataFrame],
+    anova_table: Optional[pd.DataFrame] = None,
+    block_factor_names: Tuple[str, ...] = ('Block',),
+) -> pd.DataFrame:
+    """
+    Build the canonical coefficient-level significance table.
+
+    One row per fitted coefficient (intercept excluded), p-values kept from
+    the fitted model's coefficient table.  ``parent_anova_term`` is populated
+    for labelling only and never replaces the coefficient's own statistics.
+    """
+    if effect_estimates is None or effect_estimates.empty:
+        return pd.DataFrame()
+
+    anova_terms = list(anova_table.index) if (anova_table is not None
+                                              and not anova_table.empty) else []
+
+    rows = []
+    for name, row in effect_estimates.iterrows():
+        if name in ('Intercept', 'const'):
+            continue
+        coeff = _safe_float(row.get('Coefficient'))
+        p = _safe_float(row.get('p_value'))
+        parent = find_parent_anova_term(name, anova_terms) if anova_terms else None
+        parent_df = None
+        if parent and anova_table is not None and parent in anova_table.index:
+            parent_df = _safe_int(anova_table.loc[parent, 'df'])
+        rows.append({
+            'coefficient_name': name,
+            'normalized_coefficient_name': _normalize_term(name),
+            'parent_anova_term': parent,
+            'parent_anova_df': parent_df,
+            'coefficient_estimate': coeff,
+            'standard_error': _safe_float(row.get('Std_Error')),
+            't_value': _safe_float(row.get('t_value')),
+            'p_value': p,
+            'logworth': coefficient_logworth(p),
+            'sign': np.sign(coeff) if coeff is not None and np.isfinite(coeff) else np.nan,
+            'is_block': _is_block_term(name, block_factor_names),
+            'source': 'Fitted-model coefficient test',
+        })
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Coded-to-actual-unit coefficient conversion
+# ---------------------------------------------------------------------------
+
+
+def _parse_index_term(term_name: str) -> Tuple[List[str], str]:
+    """
+    Parse a statsmodels/patsy coefficient index label into factor names and
+    operator.
+
+    Handles the following patsy output conventions:
+    - ``'Intercept'`` / ``'const'``  → ``([], '')``
+    - ``'A'``                         → ``(['A'], '')``
+    - ``'A[T.level]'``                → ``(['A'], '')``  (categorical dummy)
+    - ``'A:B'``                        → ``(['A', 'B'], ':')``
+    - ``'I(A ** 2)'``                 → ``(['A'], '**')``
+
+    Parameters
+    ----------
+    term_name : str
+        A single index label from ``fitted_model.params``.
+
+    Returns
+    -------
+    factor_names : List[str]
+        Extracted factor name(s).
+    operator : str
+        ``':'`` for interactions, ``'**'`` for quadratics, ``''`` otherwise.
+    """
+    if term_name in ("Intercept", "const"):
+        return [], ""
+
+    quad_match = re.match(r"I\((.+?)\s*\*\*\s*2\)", term_name)
+    if quad_match:
+        return [quad_match.group(1).strip()], "**"
+
+    if ":" in term_name and not term_name.startswith("I("):
+        parts = term_name.split(":")
+        clean = [re.sub(r"\[T\..*?\]", "", p).strip() for p in parts]
+        return clean, ":"
+
+    cat_match = re.match(r"^([^\[]+)\[T\.", term_name)
+    if cat_match:
+        return [cat_match.group(1).strip()], ""
+
+    return [term_name.strip()], ""
+
+
+def compute_actual_coefficients(
+    effect_estimates: pd.DataFrame,
+    factors: List[Factor],
+) -> pd.DataFrame:
+    """
+    Convert coded-unit coefficients and standard errors to actual units.
+
+    The model is fit on coded factors where each continuous factor ``x`` is
+    transformed via ``x_coded = (x_actual - center) / half_range``.  This
+    function inverts that scaling so coefficients reflect original units.
+
+    Transformation rules
+    --------------------
+    - **Intercept**: adjusted for all centering shifts.
+    - **Main effect** (continuous): ``b_actual = b_coded / half_range``
+    - **Interaction A:B** (both continuous): ``b_actual = b_coded / (hr_A*hr_B)``
+    - **Quadratic I(A**2)**: ``b_actual = b_coded / hr_A**2``
+    - **Categorical / discrete-numeric** terms: no single scale exists; the
+      corresponding ``Actual_Coefficient`` / ``Actual_Std_Error`` are set to
+      NaN (an explicit "unavailable" value) rather than a misleading number.
+
+    Parameters
+    ----------
+    effect_estimates : pd.DataFrame
+        Coefficient table with at minimum ``Coefficient`` and ``Std_Error``
+        columns and term names as the index (patsy convention).
+    factors : List[Factor]
+        Factor definitions used to retrieve ``min_value`` / ``max_value``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy with added ``Actual_Coefficient`` and ``Actual_Std_Error``.
+    """
+    scale: Dict[str, Tuple[float, float]] = {}
+    for f in factors:
+        if f.is_continuous() and f.min_value is not None and f.max_value is not None:
+            center = (f.min_value + f.max_value) / 2.0
+            half_range = (f.max_value - f.min_value) / 2.0
+            if half_range > 0:
+                scale[f.name] = (center, half_range)
+
+    result = effect_estimates.copy()
+    actual_coefs: List[float] = []
+    actual_ses: List[float] = []
+
+    intercept_adjustment = 0.0
+    for term_name in effect_estimates.index:
+        if term_name in ("Intercept", "const"):
+            continue
+        _factors, _op = _parse_index_term(term_name)
+        if _op == "" and len(_factors) == 1:
+            fname = _factors[0]
+            if fname in scale:
+                center, half_range = scale[fname]
+                b_coded = float(effect_estimates.loc[term_name, "Coefficient"])
+                intercept_adjustment += b_coded * (-center / half_range)
+
+    for term_name in effect_estimates.index:
+        b_coded = float(effect_estimates.loc[term_name, "Coefficient"])
+        se_coded = float(effect_estimates.loc[term_name, "Std_Error"])
+
+        if term_name in ("Intercept", "const"):
+            actual_coefs.append(b_coded + intercept_adjustment)
+            actual_ses.append(se_coded)
+            continue
+
+        factor_names_parsed, op = _parse_index_term(term_name)
+
+        if op == "**":
+            fname = factor_names_parsed[0]
+            if fname in scale:
+                _, half_range = scale[fname]
+                s = 1.0 / (half_range ** 2)
+                actual_coefs.append(b_coded * s)
+                actual_ses.append(se_coded * s)
+            else:
+                actual_coefs.append(float("nan"))
+                actual_ses.append(float("nan"))
+        elif op == ":":
+            if len(factor_names_parsed) == 2:
+                fa, fb = factor_names_parsed
+                if fa in scale and fb in scale:
+                    _, hr_a = scale[fa]
+                    _, hr_b = scale[fb]
+                    s = 1.0 / (hr_a * hr_b)
+                    actual_coefs.append(b_coded * s)
+                    actual_ses.append(se_coded * s)
+                else:
+                    actual_coefs.append(float("nan"))
+                    actual_ses.append(float("nan"))
+            else:
+                actual_coefs.append(float("nan"))
+                actual_ses.append(float("nan"))
+        elif op == "":
+            fname = factor_names_parsed[0]
+            if fname in scale:
+                _, half_range = scale[fname]
+                s = 1.0 / half_range
+                actual_coefs.append(b_coded * s)
+                actual_ses.append(se_coded * s)
+            else:
+                actual_coefs.append(float("nan"))
+                actual_ses.append(float("nan"))
+        else:
+            actual_coefs.append(float("nan"))
+            actual_ses.append(float("nan"))
+
+    result["Actual_Coefficient"] = actual_coefs
+    result["Actual_Std_Error"] = actual_ses
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/src/core/full_factorial.py
+++ b/src/core/full_factorial.py
@@ -17,6 +17,7 @@ from src.core.coding import decode_design as _decode_design
 def full_factorial(
     factors: List[Factor],
     n_center_points: int = 0,
+    n_replicates: int = 1,
     randomize: bool = True,
     random_seed: Optional[int] = None,
     n_blocks: Optional[int] = None
@@ -26,7 +27,7 @@ def full_factorial(
     
     A full factorial design includes all possible combinations of factor levels.
     For k factors with levels L₁, L₂, ..., Lₖ, the total number of runs is
-    L₁ × L₂ × ... × Lₖ.
+    L₁ × L₂ × ... × Lₖ, multiplied by the number of replicates.
     
     Parameters
     ----------
@@ -34,6 +35,8 @@ def full_factorial(
         List of factors to include in the design
     n_center_points : int, optional
         Number of center point runs to add (only for continuous factors), default 0
+    n_replicates : int, optional
+        Number of full replicates of the design, default 1
     randomize : bool, optional
         Whether to randomize run order, default True
     random_seed : int, optional
@@ -45,7 +48,7 @@ def full_factorial(
     -------
     pd.DataFrame
         Design matrix with columns for each factor, plus 'StdOrder', 'RunOrder',
-        and 'Block' (if n_blocks specified)
+        'Replicate' (if n_replicates > 1), and 'Block' (if n_blocks specified)
     
     Notes
     -----
@@ -55,6 +58,10 @@ def full_factorial(
     
     Center points (coded as 0) are added for continuous factors only. They provide
     an independent estimate of pure error and allow testing for curvature.
+    
+    Replicates repeat the entire base design (factorial points + center points)
+    the specified number of times. A 'Replicate' column is added to distinguish
+    runs from different replicates.
     
     Examples
     --------
@@ -88,17 +95,30 @@ def full_factorial(
     if not factors:
         raise ValueError("At least one factor must be provided")
     
+    if n_replicates < 1:
+        raise ValueError("Number of replicates must be at least 1")
+    
     # Set random seed if provided
     if random_seed is not None:
         np.random.seed(random_seed)
     
-    # Generate factorial points
-    design_matrix = _generate_factorial_points(factors)
+    # Generate base design: factorial points + center points
+    base_design = _generate_factorial_points(factors)
     
-    # Add center points if requested
     if n_center_points > 0:
         center_points = _generate_center_points(factors, n_center_points)
-        design_matrix = pd.concat([design_matrix, center_points], ignore_index=True)
+        base_design = pd.concat([base_design, center_points], ignore_index=True)
+    
+    # Replicate the base design
+    if n_replicates > 1:
+        replicated_parts = []
+        for rep in range(1, n_replicates + 1):
+            rep_copy = base_design.copy()
+            rep_copy['Replicate'] = rep
+            replicated_parts.append(rep_copy)
+        design_matrix = pd.concat(replicated_parts, ignore_index=True)
+    else:
+        design_matrix = base_design.copy()
     
     # Add standard order (before randomization)
     design_matrix.insert(0, 'StdOrder', range(1, len(design_matrix) + 1))

--- a/src/core/optimization.py
+++ b/src/core/optimization.py
@@ -184,6 +184,10 @@ class _OptimizationDims:
         self.integrality: List[int] = []  # 1 == integer dim (categorical index)
         self._categorical_index: Dict[str, int] = {}
         self._has_categorical = False
+        # Non-optimizable design columns the fitted model formula references
+        # (e.g. ``Block``). They are injected into the prediction frame at a
+        # fixed reference value so the optimizer can ignore their influence.
+        self.extra_columns: Dict[str, object] = {}
 
         for i, f in enumerate(factors):
             if f.is_continuous() or f.is_discrete_numeric():
@@ -217,28 +221,40 @@ class _OptimizationDims:
 
         Continuous/discrete dims keep their real values; categorical dims are
         snapped to the nearest level index and replaced with the declared
-        level label so the model formula can form its dummies.
+        level label so the model formula can form its dummies.  Any
+        non-optimizable columns required by the model (e.g. ``Block``) are
+        injected at their fixed reference value via ``extra_columns``.
         """
         row = {}
         for i, f in enumerate(self.factors):
-            if f.is_continuous() or f.is_discrete_numeric():
+            if f.is_continuous():
                 row[f.name] = float(x[i])
+            elif f.is_discrete_numeric():
+                row[f.name] = _nearest_level(x[i], f.levels)
             else:
                 idx = int(round(float(x[i])))
                 idx = int(np.clip(idx, 0, len(f.levels) - 1))
                 row[f.name] = f.levels[idx]
-        return pd.DataFrame([row], columns=self.names)
+        row.update(self.extra_columns)
+        return pd.DataFrame([row], columns=self.names + list(self.extra_columns))
 
     def snap_to_settings(self, x: np.ndarray) -> Dict[str, object]:
         """Map an optimizer vector to human-readable factor settings."""
         settings = {}
         for i, f in enumerate(self.factors):
-            if f.is_continuous() or f.is_discrete_numeric():
+            if f.is_continuous():
                 settings[f.name] = float(x[i])
+            elif f.is_discrete_numeric():
+                settings[f.name] = _nearest_level(x[i], f.levels)
             else:
                 idx = int(np.clip(round(float(x[i])), 0, len(f.levels) - 1))
                 settings[f.name] = f.levels[idx]
         return settings
+
+
+def _nearest_level(value: float, levels) -> float:
+    """Snap *value* to the nearest declared level for discrete factors."""
+    return min(levels, key=lambda lv: abs(float(lv) - value))
 
 
 def _pinned_categorical_defaults(factors: List[Factor]) -> Dict[str, object]:
@@ -248,6 +264,58 @@ def _pinned_categorical_defaults(factors: List[Factor]) -> Dict[str, object]:
         for f in factors
         if f.is_categorical()
     }
+
+
+# Non-optimizable design columns that may appear in a fitted model's formula
+# but are not controlled by the optimizer. They are pinned to a reference
+# level in the prediction frame so their influence is ignored.
+_NUISANCE_COLUMNS = ('Block', 'WholePlot', 'VeryHardPlot')
+
+
+def _nuisance_columns_for_model(fitted_model, factors: List[Factor]) -> Dict[str, object]:
+    """Return extra prediction columns required by *fitted_model*.
+
+    A blocked (or split-plot) design appends nuisance terms such as ``Block``
+    to its formula. The optimizer's prediction frame must contain those
+    columns for patsy to build the design matrix. Each nuisance column is set
+    to its reference (first) level so its coefficient contributes zero — the
+    block/whole-plot effect is effectively ignored, which is the desired
+    behaviour for optimization.
+
+    Parameters
+    ----------
+    fitted_model : statsmodels fitted model (OLSM/OLSResults)
+        The fitted model whose formula references the nuisance columns.
+    factors : List[Factor]
+        Optimizable factors. Columns that name a factor are skipped.
+
+    Returns
+    -------
+    Dict[str, object]
+        Map of nuisance column name -> reference level (or empty if none).
+    """
+    factor_names = {f.name for f in factors}
+    model = getattr(fitted_model, 'model', fitted_model)
+    frame = getattr(getattr(model, 'data', None), 'frame', None)
+
+    try:
+        exog_names = list(getattr(model, 'exog_names', ()) or ())
+    except Exception:
+        exog_names = []
+
+    needed = {}
+    for base in (n.split('[')[0].strip() for n in exog_names):
+        if base in factor_names or base in ('Intercept', 'const'):
+            continue
+        if base in _NUISANCE_COLUMNS:
+            # Reference level = first distinct value in the fit frame.
+            if frame is not None and base in frame.columns:
+                levels = sorted(set(frame[base].dropna().tolist()))
+                if levels:
+                    needed[base] = levels[0]
+            else:
+                needed[base] = None
+    return needed
 
 
 def optimize_response(
@@ -320,6 +388,7 @@ def optimize_response(
     model = anova_results.fitted_model
 
     dims = _OptimizationDims(factors)
+    dims.extra_columns = _nuisance_columns_for_model(model, factors)
     factor_names = dims.names
     pinned_levels = dict(pinned_levels or {})
 
@@ -916,6 +985,12 @@ def optimize_desirability(
     
     from src.core.coding import encode_design
     dims = _OptimizationDims(factors)
+    # Merge nuisance columns across every fitted response model. All models
+    # share the same design, so reference levels agree; use the first one.
+    merged: Dict[str, object] = {}
+    for anova_results in anova_results_dict.values():
+        merged.update(_nuisance_columns_for_model(anova_results.fitted_model, factors))
+    dims.extra_columns = merged
     factor_names = dims.names
     pinned_levels = dict(pinned_levels or {})
 

--- a/src/core/optimization.py
+++ b/src/core/optimization.py
@@ -90,7 +90,10 @@ def predict_with_intervals(
     PI is always wider than CI because it includes both parameter uncertainty
     and random error variance.
     """
-    pred_df = pd.DataFrame([x_pred], columns=factor_names)
+    if isinstance(x_pred, pd.DataFrame):
+        pred_df = x_pred.copy()
+    else:
+        pred_df = pd.DataFrame([x_pred], columns=factor_names)
     if model_is_coded and factors is not None:
         from src.core.coding import encode_design
         pred_df = encode_design(pred_df, factors)
@@ -156,6 +159,97 @@ class OptimizationResult:
     n_iterations: int
 
 
+# ============================================================
+# SCALAR: OPTIMIZATION DIMENSIONS
+# ============================================================
+
+
+class _OptimizationDims:
+    """Plan the optimizer search space across mixed factor types.
+
+    Continuous and discrete-numeric factors become real dimensions bounded
+    by their [min, max] values (actual units).  Categorical factors cannot be
+    optimised on their raw label value, so each is represented as an integer
+    "level index" dimension over ``[0, k-1]``.  The objective, initial point
+    and result extraction all go through :meth:`to_prediction_frame` /
+    :meth:`snap_to_settings` so categorical indices are mapped back to their
+    declared level labels before the model is asked to predict.
+    """
+
+    def __init__(self, factors: List[Factor]):
+        self.factors = factors
+        self.names = [f.name for f in factors]
+        # Bounds are always in actual space; categorical indices in [0, k-1].
+        self.bounds: List[Tuple[float, float]] = []
+        self.integrality: List[int] = []  # 1 == integer dim (categorical index)
+        self._categorical_index: Dict[str, int] = {}
+        self._has_categorical = False
+
+        for i, f in enumerate(factors):
+            if f.is_continuous() or f.is_discrete_numeric():
+                self.bounds.append((f.min_value, f.max_value))
+                self.integrality.append(0)
+            else:  # categorical
+                self._has_categorical = True
+                self._categorical_index[f.name] = i
+                self.bounds.append((0, len(f.levels) - 1))
+                self.integrality.append(1)
+
+    @property
+    def has_categorical(self) -> bool:
+        return self._has_categorical
+
+    def has_numeric(self) -> bool:
+        return any(n == 0 for n in self.integrality)
+
+    def x0(self) -> np.ndarray:
+        """Starting point: centre of each dimension (mid-index for categoricals)."""
+        x0 = np.zeros(len(self.factors))
+        for i, f in enumerate(self.factors):
+            if f.is_continuous() or f.is_discrete_numeric():
+                x0[i] = (f.min_value + f.max_value) / 2
+            else:
+                x0[i] = (len(f.levels) - 1) / 2
+        return x0
+
+    def to_prediction_frame(self, x: np.ndarray) -> pd.DataFrame:
+        """Build the prediction frame from an optimizer vector.
+
+        Continuous/discrete dims keep their real values; categorical dims are
+        snapped to the nearest level index and replaced with the declared
+        level label so the model formula can form its dummies.
+        """
+        row = {}
+        for i, f in enumerate(self.factors):
+            if f.is_continuous() or f.is_discrete_numeric():
+                row[f.name] = float(x[i])
+            else:
+                idx = int(round(float(x[i])))
+                idx = int(np.clip(idx, 0, len(f.levels) - 1))
+                row[f.name] = f.levels[idx]
+        return pd.DataFrame([row], columns=self.names)
+
+    def snap_to_settings(self, x: np.ndarray) -> Dict[str, object]:
+        """Map an optimizer vector to human-readable factor settings."""
+        settings = {}
+        for i, f in enumerate(self.factors):
+            if f.is_continuous() or f.is_discrete_numeric():
+                settings[f.name] = float(x[i])
+            else:
+                idx = int(np.clip(round(float(x[i])), 0, len(f.levels) - 1))
+                settings[f.name] = f.levels[idx]
+        return settings
+
+
+def _pinned_categorical_defaults(factors: List[Factor]) -> Dict[str, object]:
+    """Default categorical level choices (first declared level) per factor."""
+    return {
+        f.name: f.levels[0]
+        for f in factors
+        if f.is_categorical()
+    }
+
+
 def optimize_response(
     anova_results: ANOVAResults,
     factors: List[Factor],
@@ -167,6 +261,7 @@ def optimize_response(
     alpha: float = 0.05,
     seed: Optional[int] = None,
     model_is_coded: bool = False,
+    pinned_levels: Optional[Dict[str, object]] = None,
 ) -> OptimizationResult:
     """
     Find optimal factor settings for single response.
@@ -191,11 +286,17 @@ def optimize_response(
         Significance level for intervals
     seed : int, optional
         Random seed for reproducibility
+    pinned_levels : Dict[str, object], optional
+        Categorical levels to hold fixed (name -> declared level).  Any
+        categorical factor NOT listed here is treated as a free dimension and
+        the optimizer selects its best level.
     
     Returns
     -------
     OptimizationResult
-        Optimization results with optimal settings and predictions
+        Optimization results with optimal settings and predictions.  For
+        free categorical factors, ``optimal_settings`` holds the chosen level
+        label; for numeric factors a float value.
     
     Raises
     ------
@@ -215,92 +316,133 @@ def optimize_response(
     if objective == 'target' and target_value is None:
         raise ValueError("target_value must be provided when objective='target'")
     
-    # Extract model and factor names
     from src.core.coding import encode_design
     model = anova_results.fitted_model
-    factor_names = [f.name for f in factors]
 
-    # Build bounds — always in actual (natural) space so the user can
-    # interpret the results directly.
-    if bounds is None:
-        bounds_list = [(f.min_value, f.max_value) for f in factors]
-    else:
-        bounds_list = [bounds.get(f.name, (f.min_value, f.max_value)) for f in factors]
+    dims = _OptimizationDims(factors)
+    factor_names = dims.names
+    pinned_levels = dict(pinned_levels or {})
 
-    # Build objective function
+    # Apply user-supplied numeric bounds as hard bounds (actual space).
+    bounds_list = list(dims.bounds)
+    if bounds:
+        idx_by_name = {f.name: i for i, f in enumerate(factors)}
+        for name, (lo, hi) in bounds.items():
+            i = idx_by_name.get(name)
+            if i is None:
+                raise ValueError(f"Unknown factor in bounds: {name}")
+            if dims.integrality[i]:
+                raise ValueError(
+                    f"Bounds cannot be set for categorical factor '{name}'."
+                )
+            bounds_list[i] = (lo, hi)
+
+    # Apply user-pinned categorical levels as hard bounds [i, i] (fixed dim).
+    for name, level in pinned_levels.items():
+        idx = dims._categorical_index.get(name)
+        if idx is None:
+            raise ValueError(
+                f"Pinned level '{level}' for non-categorical factor '{name}'. "
+                "Only categorical factors can be pinned to a level."
+            )
+        fac = factors[idx]
+        if level not in fac.levels:
+            raise ValueError(
+                f"Level '{level}' is not a valid level for factor '{name}'. "
+                f"Valid levels: {fac.levels}"
+            )
+        li = fac.levels.index(level)
+        bounds_list[idx] = (li, li)
+
+    # Build objective function (operates on the full optimizer vector).
     def objective_func(x: np.ndarray) -> float:
         """Objective to minimize (negate for maximize)."""
-        # x is in actual space; encode to coded space only when the model
-        # was fit on a coded design (CCD/factorial).  CSV-imported designs
-        # are stored in actual space, so no encoding is needed there.
-        pred_df = pd.DataFrame([x], columns=factor_names)
+        pred_df = dims.to_prediction_frame(x)
         if model_is_coded:
             pred_df = encode_design(pred_df, factors)
         y_pred = model.predict(pred_df)[0]
-        
+
         if objective == 'maximize':
             return -y_pred  # Negate for minimization
         elif objective == 'minimize':
             return y_pred
         else:  # target
-            # Minimize squared deviation from target
             return (y_pred - target_value) ** 2
-    
+
     # Convert linear constraints to scipy format if provided
     scipy_constraints = []
     if linear_constraints is not None:
         scipy_constraints = _convert_linear_constraints(
             linear_constraints, factors
         )
-    
-    # Starting point: center of design space
-    x0 = np.array([(f.min_value + f.max_value) / 2 for f in factors])
-    
-    # Add random perturbation if seed provided
+
+    # Starting point: center of each dimension (mid-index for categoricals).
+    x0 = dims.x0()
+
+    # Add random perturbation if seed provided.
     if seed is not None:
         rng = np.random.default_rng(seed)
         perturbation = rng.uniform(-0.1, 0.1, size=len(factors))
-        ranges = np.array([f.max_value - f.min_value for f in factors])
+        ranges = np.array([b[1] - b[0] for b in dims.bounds])
         x0 = x0 + perturbation * ranges
         x0 = np.clip(x0, [b[0] for b in bounds_list], [b[1] for b in bounds_list])
-    
-    # Optimize using SLSQP (handles bounds and linear constraints)
-    result = minimize(
-        objective_func,
-        x0=x0,
-        method='SLSQP',
-        bounds=bounds_list,
-        constraints=scipy_constraints,
-        options={'maxiter': 500, 'ftol': 1e-9}
-    )
-    
-    # If failed, try differential_evolution (global optimizer)
-    if not result.success:
-        warnings.warn(
-            f"SLSQP failed: {result.message}. Trying global optimizer..."
-        )
-        from scipy.optimize import differential_evolution
-        
-        result = differential_evolution(
+        if dims.has_categorical:
+            # Centre categorical dims on integer indices before snapping.
+            for i, is_int in enumerate(dims.integrality):
+                if is_int:
+                    x0[i] = round(x0[i])
+
+    # Choose the solver: SLSQP for pure-numeric designs (unchanged behaviour);
+    # differential_evolution with integrality when categoricals are present.
+    if not dims.has_categorical:
+        result = minimize(
             objective_func,
+            x0=x0,
+            method='SLSQP',
             bounds=bounds_list,
-            constraints=scipy_constraints if scipy_constraints else None,
-            seed=seed,
-            maxiter=300,
-            atol=1e-9,
-            tol=1e-9
+            constraints=scipy_constraints,
+            options={'maxiter': 500, 'ftol': 1e-9}
         )
-    
-    # Extract optimal settings
+    else:
+        result = None
+        if scipy_constraints:
+            warnings.warn(
+                "Linear constraints are ignored for designs containing "
+                "categorical factors."
+            )
+        try:
+            from scipy.optimize import differential_evolution
+            result = differential_evolution(
+                objective_func,
+                bounds=bounds_list,
+                integrality=dims.integrality,
+                maxiter=500,
+                popsize=20,
+                seed=seed,
+                polish=False,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            warnings.warn(f"differential_evolution failed: {exc}")
+
+        if result is None or not result.success:
+            # Fallback: expand discrete leaves and compare directly.
+            warnings.warn(
+                "Global categorical optimizer did not converge; enumerating "
+                "categorical level combinations instead."
+            )
+            result = _enumerate_categorical_best(objective_func, dims)
+
+    # Extract optimal settings (numeric floats; categorical level labels).
     x_opt = result.x
-    optimal_settings = {factor_names[i]: x_opt[i] for i in range(len(factors))}
-    
-    # Predict at optimum with intervals
+    optimal_settings = dims.snap_to_settings(x_opt)
+
+    # Predict at optimum with intervals.
+    pred_df = dims.to_prediction_frame(x_opt)
     pred, ci, pi = predict_with_intervals(
-        model, x_opt, factor_names,
+        model, pred_df, factor_names,
         factors=factors, model_is_coded=model_is_coded, alpha=alpha
     )
-    
+
     return OptimizationResult(
         optimal_settings=optimal_settings,
         predicted_response=pred,
@@ -308,8 +450,66 @@ def optimize_response(
         prediction_interval=pi,
         objective_value=result.fun,
         success=result.success,
-        message=result.message,
+        message=getattr(result, 'message', ''),
         n_iterations=result.nit if hasattr(result, 'nit') else 0
+    )
+
+
+def _enumerate_categorical_best(
+    objective_func: Callable[[np.ndarray], float],
+    dims: _OptimizationDims,
+) -> object:
+    """Brute-force the categorical dimensions.
+
+    Used as a last-resort fallback when differential_evolution is unavailable
+    or does not converge.  Only valid when every dimension is categorical
+    (no free numeric dims); otherwise we return a nominal failure result so
+    the caller surfaces a clear message rather than a wrong answer.
+    """
+    from types import SimpleNamespace
+
+    if dims.has_numeric():
+        return SimpleNamespace(
+            x=np.zeros(len(dims.factors)),
+            fun=float('inf'),
+            success=False,
+            message=(
+                "Optimization failed for categorical + numeric design: "
+                "global solver unavailable."
+            ),
+            nit=0,
+        )
+
+    cat_indices = [i for i, n in enumerate(dims.integrality) if n == 1]
+    if not cat_indices:
+        return SimpleNamespace(
+            x=dims.x0(), fun=float('inf'), success=False,
+            message="No dimensions to optimize.", nit=0,
+        )
+
+    axis_count = [len(dims.factors[i].levels) for i in cat_indices]
+
+    best = None
+    best_fun = float('inf')
+    total = 1
+    for c in axis_count:
+        total *= c
+
+    for flat in range(total):
+        x = dims.x0()
+        rem = flat
+        for pos, counts in enumerate(axis_count):
+            x[cat_indices[pos]] = rem % counts
+            rem //= counts
+        fun = objective_func(x)
+        if fun < best_fun:
+            best_fun = fun
+            best = x.copy()
+
+    return SimpleNamespace(
+        x=best, fun=best_fun, success=True,
+        message=f"Enumerated {total} categorical combination(s).",
+        nit=total,
     )
 
 
@@ -663,6 +863,7 @@ def optimize_desirability(
     linear_constraints: Optional[List['LinearConstraint']] = None,
     seed: Optional[int] = None,
     model_is_coded: bool = False,
+    pinned_levels: Optional[Dict[str, object]] = None,
 ) -> DesirabilityResult:
     """
     Optimize multiple responses using desirability functions.
@@ -681,11 +882,17 @@ def optimize_desirability(
         Linear constraints on factors
     seed : int, optional
         Random seed
+    pinned_levels : Dict[str, object], optional
+        Categorical levels to hold fixed (name -> declared level).  Any
+        categorical factor NOT listed here is a free dimension and the
+        optimizer selects its best level.
     
     Returns
     -------
     DesirabilityResult
-        Optimization results with optimal settings and desirabilities
+        Optimization results with optimal settings and desirabilities.  For
+        free categorical factors, ``optimal_settings`` holds the chosen level
+        label; for numeric factors a float.
     
     Examples
     --------
@@ -708,18 +915,45 @@ def optimize_desirability(
             raise ValueError(f"No model provided for response: {response_name}")
     
     from src.core.coding import encode_design
-    factor_names = [f.name for f in factors]
+    dims = _OptimizationDims(factors)
+    factor_names = dims.names
+    pinned_levels = dict(pinned_levels or {})
 
-    # Build bounds — always in actual (natural) space.
-    if bounds is None:
-        bounds_list = [(f.min_value, f.max_value) for f in factors]
-    else:
-        bounds_list = [bounds.get(f.name, (f.min_value, f.max_value)) for f in factors]
+    # Apply user-supplied numeric bounds as hard bounds (actual space).
+    bounds_list = list(dims.bounds)
+    if bounds:
+        idx_by_name = {f.name: i for i, f in enumerate(factors)}
+        for name, (lo, hi) in bounds.items():
+            i = idx_by_name.get(name)
+            if i is None:
+                raise ValueError(f"Unknown factor in bounds: {name}")
+            if dims.integrality[i]:
+                raise ValueError(
+                    f"Bounds cannot be set for categorical factor '{name}'."
+                )
+            bounds_list[i] = (lo, hi)
+
+    # Apply user-pinned categorical levels as fixed dimensions.
+    for name, level in pinned_levels.items():
+        idx = dims._categorical_index.get(name)
+        if idx is None:
+            raise ValueError(
+                f"Pinned level '{level}' for non-categorical factor '{name}'. "
+                "Only categorical factors can be pinned to a level."
+            )
+        fac = factors[idx]
+        if level not in fac.levels:
+            raise ValueError(
+                f"Level '{level}' is not a valid level for factor '{name}'. "
+                f"Valid levels: {fac.levels}"
+            )
+        li = fac.levels.index(level)
+        bounds_list[idx] = (li, li)
 
     # Build objective function (maximize overall desirability)
     def objective_func(x: np.ndarray) -> float:
         """Objective to minimize (negate desirability)."""
-        pred_df = pd.DataFrame([x], columns=factor_names)
+        pred_df = dims.to_prediction_frame(x)
         if model_is_coded:
             pred_df = encode_design(pred_df, factors)
 
@@ -743,48 +977,62 @@ def optimize_desirability(
         )
     
     # Starting point
-    x0 = np.array([(f.min_value + f.max_value) / 2 for f in factors])
+    x0 = dims.x0()
     
     if seed is not None:
         rng = np.random.default_rng(seed)
         perturbation = rng.uniform(-0.1, 0.1, size=len(factors))
-        ranges = np.array([f.max_value - f.min_value for f in factors])
+        ranges = np.array([b[1] - b[0] for b in dims.bounds])
         x0 = x0 + perturbation * ranges
         x0 = np.clip(x0, [b[0] for b in bounds_list], [b[1] for b in bounds_list])
+        if dims.has_categorical:
+            for i, is_int in enumerate(dims.integrality):
+                if is_int:
+                    x0[i] = round(x0[i])
     
-    # Optimize
-    result = minimize(
-        objective_func,
-        x0=x0,
-        method='SLSQP',
-        bounds=bounds_list,
-        constraints=scipy_constraints,
-        options={'maxiter': 500, 'ftol': 1e-9}
-    )
-    
-    # If failed, try global optimizer
-    if not result.success:
-        warnings.warn(
-            f"SLSQP failed: {result.message}. Trying global optimizer..."
-        )
-        from scipy.optimize import differential_evolution
-        
-        result = differential_evolution(
+    if not dims.has_categorical:
+        result = minimize(
             objective_func,
+            x0=x0,
+            method='SLSQP',
             bounds=bounds_list,
-            constraints=scipy_constraints if scipy_constraints else None,
-            seed=seed,
-            maxiter=300,
-            atol=1e-9,
-            tol=1e-9
+            constraints=scipy_constraints,
+            options={'maxiter': 500, 'ftol': 1e-9}
         )
+    else:
+        result = None
+        if scipy_constraints:
+            warnings.warn(
+                "Linear constraints are ignored for designs containing "
+                "categorical factors."
+            )
+        try:
+            from scipy.optimize import differential_evolution
+            result = differential_evolution(
+                objective_func,
+                bounds=bounds_list,
+                integrality=dims.integrality,
+                maxiter=500,
+                popsize=20,
+                seed=seed,
+                polish=False,
+            )
+        except Exception as exc:
+            warnings.warn(f"differential_evolution failed: {exc}")
+
+        if result is None or not result.success:
+            warnings.warn(
+                "Global categorical optimizer did not converge; enumerating "
+                "categorical level combinations instead."
+            )
+            result = _enumerate_categorical_best(objective_func, dims)
     
-    # Extract optimal settings
+    # Extract optimal settings (numeric floats; categorical level labels).
     x_opt = result.x
-    optimal_settings = {factor_names[i]: x_opt[i] for i in range(len(factors))}
+    optimal_settings = dims.snap_to_settings(x_opt)
     
     # Predict all responses at optimum.
-    pred_df = pd.DataFrame([x_opt], columns=factor_names)
+    pred_df = dims.to_prediction_frame(x_opt)
     if model_is_coded:
         pred_df = encode_design(pred_df, factors)
     predicted_responses = {}
@@ -806,7 +1054,7 @@ def optimize_desirability(
         individual_desirabilities=individual_desirabilities,
         overall_desirability=overall_D,
         success=result.success,
-        message=result.message,
+        message=getattr(result, 'message', ''),
         n_iterations=result.nit if hasattr(result, 'nit') else 0
     )
 

--- a/src/core/optimization.py
+++ b/src/core/optimization.py
@@ -22,7 +22,7 @@ from typing import List, Dict, Optional, Union, Literal, Tuple, Callable
 from dataclasses import dataclass
 import numpy as np
 import pandas as pd
-from scipy.optimize import minimize, LinearConstraint as ScipyLinearConstraint
+from scipy.optimize import minimize, differential_evolution, LinearConstraint as ScipyLinearConstraint
 
 from src.core.factors import Factor, FactorType
 from src.core.analysis import ANOVAResults
@@ -594,16 +594,16 @@ def desirability_maximize(
     weight: float = 1.0
 ) -> float:
     """
-    Desirability function for maximizing response.
+    Desirability function for maximizing response (Derringer & Suich, 1980).
     
     Parameters
     ----------
     y : float
         Response value
     low : float
-        Minimum acceptable value (d=0)
+        Worst acceptable value (d=0)
     high : float
-        Target value (d=1)
+        Ideal value (d=1); values at or above it are fully satisfactory
     weight : float, default=1.0
         Shape parameter (1=linear, >1=emphasize target, <1=more tolerant)
     
@@ -614,13 +614,14 @@ def desirability_maximize(
     
     Notes
     -----
-    Formula: d = ((y - low) / (high - low))^weight for low <= y <= high
-             d = 0 for y < low
-             d = 1 for y > high
+    Standard Derringer & Suich semantics:
+        d = ((y - low) / (high - low))^weight  for low <= y < high
+        d = 0                                   for y < low
+        d = 1                                   for y >= high  (saturates at ideal)
     """
     if y < low:
         return 0.0
-    elif y > high:
+    elif y >= high:
         return 1.0
     else:
         return ((y - low) / (high - low)) ** weight
@@ -633,16 +634,16 @@ def desirability_minimize(
     weight: float = 1.0
 ) -> float:
     """
-    Desirability function for minimizing response.
+    Desirability function for minimizing response (Derringer & Suich, 1980).
     
     Parameters
     ----------
     y : float
         Response value
     low : float
-        Target value (d=1)
+        Ideal value (d=1); values at or below it are fully satisfactory
     high : float
-        Maximum acceptable value (d=0)
+        Worst acceptable value (d=0)
     weight : float, default=1.0
         Shape parameter
     
@@ -653,11 +654,12 @@ def desirability_minimize(
     
     Notes
     -----
-    Formula: d = ((high - y) / (high - low))^weight for low <= y <= high
-             d = 1 for y < low
-             d = 0 for y > high
+    Standard Derringer & Suich semantics:
+        d = ((high - y) / (high - low))^weight  for low < y <= high
+        d = 1                                   for y <= low  (saturates at ideal)
+        d = 0                                   for y > high
     """
-    if y < low:
+    if y <= low:
         return 1.0
     elif y > high:
         return 0.0
@@ -983,6 +985,13 @@ def optimize_desirability(
         if response_name not in anova_results_dict:
             raise ValueError(f"No model provided for response: {response_name}")
     
+    # Guard against nothing to optimize (all responses set to "None")
+    if not desirability_func.response_names:
+        raise ValueError(
+            "No responses configured for desirability optimization. "
+            "Set at least one response to maximize, minimize, or target."
+        )
+    
     from src.core.coding import encode_design
     dims = _OptimizationDims(factors)
     # Merge nuisance columns across every fitted response model. All models
@@ -1065,42 +1074,34 @@ def optimize_desirability(
                 if is_int:
                     x0[i] = round(x0[i])
     
-    if not dims.has_categorical:
-        result = minimize(
-            objective_func,
-            x0=x0,
-            method='SLSQP',
-            bounds=bounds_list,
-            constraints=scipy_constraints,
-            options={'maxiter': 500, 'ftol': 1e-9}
+    # Always use global (gradient-free) solver for desirability optimization.
+    # Hard bounds create a discontinuous objective that gradient-based methods
+    # (SLSQP) cannot navigate — the numerical gradient vanishes in the flat
+    # d=0 region and the solver stalls at the starting point.
+    if scipy_constraints:
+        warnings.warn(
+            "Linear constraints are ignored for desirability optimization."
         )
-    else:
+    try:
+        result = differential_evolution(
+            objective_func,
+            bounds=bounds_list,
+            integrality=dims.integrality,
+            maxiter=500,
+            popsize=20,
+            seed=seed,
+            polish=False,
+        )
+    except Exception as exc:
+        warnings.warn(f"differential_evolution failed: {exc}")
         result = None
-        if scipy_constraints:
-            warnings.warn(
-                "Linear constraints are ignored for designs containing "
-                "categorical factors."
-            )
-        try:
-            from scipy.optimize import differential_evolution
-            result = differential_evolution(
-                objective_func,
-                bounds=bounds_list,
-                integrality=dims.integrality,
-                maxiter=500,
-                popsize=20,
-                seed=seed,
-                polish=False,
-            )
-        except Exception as exc:
-            warnings.warn(f"differential_evolution failed: {exc}")
 
-        if result is None or not result.success:
-            warnings.warn(
-                "Global categorical optimizer did not converge; enumerating "
-                "categorical level combinations instead."
-            )
-            result = _enumerate_categorical_best(objective_func, dims)
+    if result is None or not result.success:
+        warnings.warn(
+            "Global optimizer did not converge; enumerating "
+            "categorical level combinations instead."
+        )
+        result = _enumerate_categorical_best(objective_func, dims)
     
     # Extract optimal settings (numeric floats; categorical level labels).
     x_opt = result.x
@@ -1118,8 +1119,10 @@ def optimize_desirability(
         y_pred = model.predict(pred_df)[0]
         predicted_responses[response_name] = y_pred
         
-        d_i = desirability_func.evaluate_individual(response_name, y_pred)
-        individual_desirabilities[response_name] = d_i
+        # Only evaluate desirability for configured responses
+        if response_name in desirability_func.response_configs:
+            d_i = desirability_func.evaluate_individual(response_name, y_pred)
+            individual_desirabilities[response_name] = d_i
     
     overall_D = desirability_func.evaluate(predicted_responses)
     

--- a/src/core/split_plot_analysis.py
+++ b/src/core/split_plot_analysis.py
@@ -27,7 +27,14 @@ import statsmodels.api as sm
 from statsmodels.formula.api import ols
 
 from src.core.factors import Factor, ChangeabilityLevel
-from src.core.analysis_base import ANOVAResults, parse_model_term
+from src.core.analysis_base import (
+    ANOVAResults,
+    build_anova_effect_summary,
+    build_coefficient_significance,
+    compute_actual_coefficients,
+    find_effect_estimate_key,
+    parse_model_term,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -622,17 +629,30 @@ def fit_split_plot_anova(
             lw = 16.0
         else:
             lw = -np.log10(p)
+        key = find_effect_estimate_key(source, effect_estimates.index)
+        coefficient = (
+            effect_estimates.loc[key, 'Coefficient']
+            if key is not None else np.nan
+        )
         logworth_rows.append({
             'Source': source,
-            'Coefficient': effect_estimates.loc[
-                _find_effect_estimate_key(source, effect_estimates.index), 'Coefficient'
-            ] if _find_effect_estimate_key(source, effect_estimates.index) else np.nan,
+            'Coefficient': coefficient,
             'p_value': p,
             'LogWorth': lw,
             'Stratum': row['Stratum'],
         })
 
     logworth_df = pd.DataFrame(logworth_rows).set_index('Source')
+
+    # Canonical effect tables (kept distinct: coefficient-level vs ANOVA
+    # term-level).  Used by the two effect charts in the UI.
+    block_names = ('Block',) if design_structure.get('has_blocking') else ()
+    coefficient_significance = build_coefficient_significance(
+        effect_estimates, anova_table, block_factor_names=block_names
+    )
+    anova_effect_summary = build_anova_effect_summary(
+        anova_table, effect_estimates, block_factor_names=block_names
+    )
 
     return ANOVAResults(
         anova_table=anova_table,
@@ -647,37 +667,6 @@ def fit_split_plot_anova(
         r_squared=r_squared,
         adj_r_squared=adj_r_squared,
         rmse=rmse,
+        coefficient_significance=coefficient_significance,
+        anova_effect_summary=anova_effect_summary,
     )
-
-
-def _find_effect_estimate_key(
-    source: str,
-    index: pd.Index,
-) -> Optional[str]:
-    """
-    Map an ANOVA source label back to a coefficient table index entry.
-
-    Parameters
-    ----------
-    source : str
-        ANOVA table source name (e.g. 'Temperature', 'Temperature*Time').
-    index : pd.Index
-        Index of the effect_estimates DataFrame.
-
-    Returns
-    -------
-    str or None
-        Matching key, or None if not found.
-    """
-    # Direct match
-    if source in index:
-        return source
-    # Interaction: 'A*B' -> 'A:B' in patsy
-    patsy_form = source.replace('*', ':')
-    if patsy_form in index:
-        return patsy_form
-    # Partial match for categorical dummies
-    for key in index:
-        if key.startswith(source) or key.startswith(patsy_form):
-            return key
-    return None

--- a/src/ui/components/alias_display.py
+++ b/src/ui/components/alias_display.py
@@ -120,7 +120,7 @@ def _render_body(
     # Heatmap
     st.markdown("**Term Correlation Heatmap** (|r|)")
     fig = _build_heatmap(corr, col_labels)
-    st.plotly_chart(fig, use_container_width=True, theme=None)
+    st.plotly_chart(fig, width="stretch", theme=None)
 
     # Flagged pairs table
     flagged = _find_flagged_pairs(corr, col_labels)
@@ -132,7 +132,7 @@ def _render_body(
         flagged_df = pd.DataFrame(
             flagged, columns=["Term A", "Term B", "|r|"]
         ).sort_values("|r|", ascending=False)
-        st.dataframe(flagged_df, hide_index=True, use_container_width=True)
+        st.dataframe(flagged_df, hide_index=True, width="stretch")
     else:
         st.success(
             f"✅ No term pairs with |r| ≥ {_ALIAS_FLAG_THRESHOLD:.1f}. "
@@ -423,7 +423,7 @@ def _render_alias_chains(
 
     if rows:
         alias_df = pd.DataFrame(rows)
-        st.dataframe(alias_df, hide_index=True, use_container_width=True)
+        st.dataframe(alias_df, hide_index=True, width="stretch")
     else:
         st.info("No alias chains up to 3rd order.")
 

--- a/src/ui/components/augmentation_wizard.py
+++ b/src/ui/components/augmentation_wizard.py
@@ -158,7 +158,7 @@ def display_type_selection(
                         "Select",
                         key=f"select_type_{entry['type']}",
                         type="primary",
-                        use_container_width=True,
+                        width="stretch",
                     ):
                         selected_type = entry['type']
                 else:
@@ -166,7 +166,7 @@ def display_type_selection(
                         "Locked",
                         key=f"locked_type_{entry['type']}",
                         disabled=True,
-                        use_container_width=True,
+                        width="stretch",
                         help=lock_reason or "Not available for this design.",
                     )
 

--- a/src/ui/components/box_plot_display.py
+++ b/src/ui/components/box_plot_display.py
@@ -1,0 +1,150 @@
+"""
+Box Plot component for ANOVA analysis.
+
+Draws a Tukey (IQR) box plot of the selected response grouped by the levels
+of a user-chosen factor, so the distribution of the measured response can be
+compared across factor levels at a glance.  Boxes are built from the observed
+response values (not adjusted means); only factor levels present in the
+filtered data are shown.
+
+The heavy lifting is done by the pure, testable functions
+:func:`box_plot_stats` and :func:`create_box_plot` in ``src/ui/utils/plotting.py``;
+this module only wires up Streamlit controls and renders the resulting figure.
+"""
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+from src.ui.utils.plotting import (
+    box_plot_stats,
+    create_box_plot,
+)
+
+
+def _response_values_by_level(
+    factor_name: str,
+    design: pd.DataFrame,
+    response: np.ndarray,
+) -> Dict[str, np.ndarray]:
+    """Map each factor level string to its raw, NaN-free response values."""
+    values: Dict[str, np.ndarray] = {}
+    for _, row in design.iterrows():
+        level = str(row[factor_name])
+        y = response[row.name]
+        if pd.isna(y):
+            continue
+        values.setdefault(level, []).append(float(y))
+    return {k: np.asarray(v, dtype=float) for k, v in values.items()}
+
+
+def _factor_units_map(factors) -> Dict[str, Optional[str]]:
+    return {f.name: getattr(f, "units", None) for f in factors}
+
+
+def display_box_plot_tab(
+    selected_response: str,
+    design: pd.DataFrame,
+    response: np.ndarray,
+    factors: List,
+    factor_names_order: Optional[List[str]] = None,
+    response_units: Optional[str] = None,
+) -> None:
+    """
+    Display the Box Plots tab content.
+
+    Parameters
+    ----------
+    selected_response : str
+        Name of the currently selected response.
+    design : pd.DataFrame
+        Filtered design data (natural units) aligned with ``response``.
+    response : np.ndarray
+        Response values aligned with ``design`` rows.
+    factors : List[Factor]
+        Factor definitions.
+    factor_names_order : list of str, optional
+        Preferred order for the x-axis factor choices (defaults to factor
+        definition order).
+    response_units : str, optional
+        Units for the response (e.g. "kg"). If None, no units shown.
+
+    Returns
+    -------
+    None
+        Displays content directly in Streamlit.
+    """
+    st.subheader("📦 Box Plots")
+    st.caption(
+        "Distribution of the selected response across the levels of a chosen "
+        "factor.  Each box shows min, Q1, median, Q3 and max; points beyond "
+        "the Tukey whiskers (1.5×IQR) are drawn as outliers."
+    )
+
+    if not factors:
+        st.info("No factors defined.")
+        st.stop()
+
+    if len(response) == 0 or np.all(pd.isna(response)):
+        st.warning("No response data available to plot.")
+        st.stop()
+
+    factor_names = [f.name for f in factors]
+    if factor_names_order:
+        ordered = [n for n in factor_names_order if n in factor_names]
+        remaining = [n for n in factor_names if n not in factor_names_order]
+        factor_names = ordered + remaining
+
+    units_map = _factor_units_map(factors)
+
+    factor_name = st.selectbox(
+        "Factor (x-axis)",
+        factor_names,
+        key="bx_factor",
+        help="Distributions of the response are shown for each level of this factor.",
+    )
+
+    if factor_name is None:
+        st.info("Select a factor to build the box plot.")
+        st.stop()
+
+    if factor_name not in design.columns:
+        st.error(f"Factor {factor_name!r} not found in design data.")
+        st.stop()
+
+    factor = next(f for f in factors if f.name == factor_name)
+
+    stats = box_plot_stats(
+        factor_name, design, response, is_categorical=factor.is_categorical()
+    )
+
+    if stats.empty:
+        st.warning("No complete data for this factor.")
+        st.stop()
+
+    values_map = _response_values_by_level(factor_name, design, response)
+    values_map = {k: v for k, v in values_map.items() if k in set(stats['level'])}
+
+    fig = create_box_plot(
+        stats,
+        factor_name,
+        factor_name,
+        selected_response,
+        values_map,
+        response_units=response_units,
+        factor_units=units_map.get(factor_name),
+    )
+
+    # Faint dashed gridlines on the value (y) axis only, no grid on the
+    # category (x) axis, so the black box outlines read cleanly.
+    fig.update_yaxes(
+        showgrid=True,
+        gridcolor="#dcdcdc",
+        gridwidth=0.5,
+        griddash="dash",
+    )
+    fig.update_xaxes(showgrid=False)
+
+    st.plotly_chart(fig, width="stretch", theme=None)

--- a/src/ui/components/interaction_display.py
+++ b/src/ui/components/interaction_display.py
@@ -1,0 +1,201 @@
+"""
+Interaction Plot component for ANOVA analysis.
+
+Stat-Ease / Design-Expert style interaction plots.  For a selected pair of
+factors ``A`` and ``B`` it draws one line per level of the grouping factor
+across the levels of the x-axis factor, using per-combination observed means.
+Parallel lines indicate little to no interaction; crossing / non-parallel
+lines indicate an interaction.
+
+Two renderings are produced for every pair (``A`` on the x-axis with ``B``
+as the grouping factor, and the swapped orientation) so the user can inspect
+the interaction from both points of view.
+
+The heavy lifting is done by the pure, testable functions
+:func:`interaction_stats` and :func:`create_interaction_plot` in
+``src/ui/utils/plotting.py``; this module only wires up Streamlit controls
+and renders the resulting figures.
+"""
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+from src.ui.utils.plotting import (
+    interaction_stats,
+    create_interaction_plot,
+)
+
+# Error-bar display modes offered to the user.  Keys match the values the
+# plot builder understands.
+_ERROR_MODES: List[str] = ["Mean only", "Mean ± SD", "Mean ± CI"]
+_ERROR_MODE_MAP: Dict[str, str] = {
+    "Mean only": "none",
+    "Mean ± SD": "sd",
+    "Mean ± CI": "ci",
+}
+
+
+def _interaction_pvalue(results, f1_name: str, f2_name: str):
+    """
+    Look up the ANOVA interaction-term p-value for a factor pair.
+
+    Returns ``(p_value, present)``.  ``present`` is ``False`` when the
+    interaction term is not part of the fitted model, in which case the caller
+    should show "not in model" rather than an error.  Handles both standard
+    statsmodels tables (``PR(>F)`` column) and split-plot tables (``P``).
+    """
+    if results is None or results.anova_table is None or results.anova_table.empty:
+        return None, False
+
+    key = f"{f1_name}:{f2_name}"
+    reversed_key = f"{f2_name}:{f1_name}"
+    index_names = [str(i) for i in results.anova_table.index]
+    if key not in index_names and reversed_key not in index_names:
+        return None, False
+
+    search = key if key in index_names else reversed_key
+    row_idx = results.anova_table.index[index_names.index(search)]
+    col = "PR(>F)" if "PR(>F)" in results.anova_table.columns else "P"
+    val = results.anova_table.loc[row_idx, col]
+    if pd.isna(val) or not np.isfinite(float(val)):
+        return None, True
+    return float(val), True
+
+
+def _factor_units_map(factors) -> Dict[str, Optional[str]]:
+    return {f.name: getattr(f, "units", None) for f in factors}
+
+
+def display_interaction_plot_tab(
+    selected_response: str,
+    design: pd.DataFrame,
+    response: np.ndarray,
+    factors: List,
+    results=None,
+    response_units: Optional[str] = None,
+) -> None:
+    """
+    Display the Interaction Plots tab content.
+
+    Parameters
+    ----------
+    selected_response : str
+        Name of the currently selected response.
+    design : pd.DataFrame
+        Filtered design data (natural units) aligned with ``response``.
+    response : np.ndarray
+        Response values aligned with ``design`` rows.
+    factors : List[Factor]
+        Factor definitions.
+    results : ANOVAResults, optional
+        Fitted model results used to source the interaction p-value overlay.
+    response_units : str, optional
+        Units for the response (e.g. "kg"). If None, no units shown.
+
+    Returns
+    -------
+    None
+        Displays content directly in Streamlit.
+    """
+    st.subheader("📊 Interaction Plots")
+    st.caption(
+        "Mean response at each factor combination.  Parallel lines indicate "
+        "little interaction; crossing / non-parallel lines indicate interaction."
+    )
+
+    if len(factors) < 2:
+        st.info("At least two factors are required for interaction plots.")
+        st.stop()
+
+    if len(response) == 0 or np.all(pd.isna(response)):
+        st.warning("No response data available to plot.")
+        st.stop()
+
+    units_map = _factor_units_map(factors)
+    factor_names = [f.name for f in factors]
+
+    col1, col2, col3 = st.columns([2, 2, 2])
+    with col1:
+        f1_name = st.selectbox(
+            "Factor A (x-axis)", factor_names, key="ix_f1",
+            help="Levels of this factor appear on the horizontal axis.",
+        )
+    with col2:
+        f2_options = [n for n in factor_names if n != f1_name]
+        f2_name = st.selectbox(
+            "Factor B (lines)", f2_options, key="ix_f2",
+            help="One line is drawn for each level of this factor.",
+        )
+    with col3:
+        error_mode_label = st.radio(
+            "Error bars",
+            _ERROR_MODES,
+            index=0,
+            key="ix_error_mode",
+            horizontal=True,
+            help="Mean only, or mean ± SD / 95% CI for replicated runs.",
+        )
+
+    if f1_name is None or f2_name is None:
+        st.info("Select a pair of factors to build the interaction plot.")
+        st.stop()
+
+    f1 = next(f for f in factors if f.name == f1_name)
+    f2 = next(f for f in factors if f.name == f2_name)
+    error_mode = _ERROR_MODE_MAP[error_mode_label]
+
+    p_value, present = _interaction_pvalue(results, f1_name, f2_name)
+
+    # Guard against factors whose names are missing from the design.
+    if f1_name not in design.columns or f2_name not in design.columns:
+        st.error(f"Factors {f1_name!r} / {f2_name!r} not found in design data.")
+        st.stop()
+
+    stats = interaction_stats(f1_name, f2_name, design, response)
+
+    if stats.empty:
+        st.warning("No complete data for this factor pair.")
+        st.stop()
+
+    plot_params = {
+        "response_name": selected_response,
+        "response_units": response_units,
+        "f1_units": units_map.get(f1_name),
+        "f2_units": units_map.get(f2_name),
+        "error_mode": error_mode,
+        "p_value": p_value,
+        "interaction_present": present,
+    }
+
+    # Orientation 1: A on the x-axis, B as line colour/group.
+    fig1 = create_interaction_plot(
+        stats,
+        f1_name,
+        f2_name,
+        f1.is_categorical(),
+        f2.is_categorical(),
+        **plot_params,
+    )
+
+    # Orientation 2: B on the x-axis, A as line colour/group.
+    fig2 = create_interaction_plot(
+        stats,
+        f2_name,
+        f1_name,
+        f2.is_categorical(),
+        f1.is_categorical(),
+        **plot_params,
+    )
+
+    c1, c2 = st.columns(2)
+    with c1:
+        st.markdown(f"**{f1_name} × {f2_name}**")
+        st.caption(f"{f1_name} on the x-axis, lines = {f2_name}.")
+        st.plotly_chart(fig1, width="stretch", theme=None)
+    with c2:
+        st.markdown(f"**{f2_name} × {f1_name}**")
+        st.caption(f"{f2_name} on the x-axis, lines = {f1_name}.")
+        st.plotly_chart(fig2, width="stretch", theme=None)

--- a/src/ui/pages/3_choose_design.py
+++ b/src/ui/pages/3_choose_design.py
@@ -232,6 +232,14 @@ if st.session_state.get('design_type'):
             help="Full repetitions of entire design"
         )
         
+        n_blocks = st.number_input(
+            "Number of Blocks",
+            min_value=1,
+            max_value=10,
+            value=1,
+            help="Divide runs into blocks to account for nuisance variation. Use 1 for no blocking."
+        )
+        
         randomize = st.checkbox("Randomize Run Order", value=True)
         
         # Store config
@@ -239,11 +247,13 @@ if st.session_state.get('design_type'):
             'n_levels': n_levels,
             'n_center_points': n_center_points,
             'n_replicates': n_replicates,
+            'n_blocks': n_blocks,
             'randomize': randomize
         }
         
         # Estimate runs
-        total_runs = (n_levels ** len(factors)) * n_replicates + n_center_points
+        base_runs = n_levels ** len(factors)
+        total_runs = (base_runs + n_center_points) * n_replicates
         st.info(f"**Estimated runs:** {total_runs}")
     
     elif design_type == "Fractional Factorial":
@@ -317,6 +327,14 @@ if st.session_state.get('design_type'):
             value=3
         )
         
+        n_blocks = st.number_input(
+            "Number of Blocks",
+            min_value=1,
+            max_value=10,
+            value=1,
+            help="Divide runs into blocks to account for nuisance variation. Use 1 for no blocking."
+        )
+        
         randomize = st.checkbox("Randomize Run Order", value=True)
         
         # Store config
@@ -326,6 +344,7 @@ if st.session_state.get('design_type'):
             'generator_mode': generator_mode,
             'custom_generators': custom_generators,
             'n_center_points': n_center_points,
+            'n_blocks': n_blocks,
             'randomize': randomize
         }
         

--- a/src/ui/pages/4_preview_design.py
+++ b/src/ui/pages/4_preview_design.py
@@ -254,12 +254,14 @@ if st.session_state.get('design') is None:
                 if design_type == "Full Factorial":
                     from src.core.full_factorial import full_factorial
                     
+                    n_blocks = design_config.get('n_blocks', 1)
                     design = full_factorial(
                         factors=factors,
-                        n_center_points = design_config.get('n_center_points', 0),
+                        n_center_points=design_config.get('n_center_points', 0),
+                        n_replicates=design_config.get('n_replicates', 1),
                         randomize=st.session_state.get('randomize', True),
                         random_seed=st.session_state.get('random_seed'),
-                        n_blocks=st.session_state.get('n_blocks')
+                        n_blocks=None if n_blocks <= 1 else n_blocks
                     )
                     
                     metadata = {
@@ -284,10 +286,11 @@ if st.session_state.get('design') is None:
                     )
                     
                     # Generate design
+                    n_ff_blocks = design_config.get('n_blocks', 1)
                     design = ff.generate(
                         randomize=st.session_state.get('randomize', True),
                         random_seed=st.session_state.get('random_seed'),
-                        n_blocks=st.session_state.get('n_blocks')
+                        n_blocks=None if n_ff_blocks <= 1 else n_ff_blocks
                     )
                     
                     # Store metadata

--- a/src/ui/pages/4_preview_design.py
+++ b/src/ui/pages/4_preview_design.py
@@ -14,7 +14,6 @@ import streamlit as st
 import pandas as pd
 import numpy as np
 from datetime import datetime
-import re
 
 from src.ui.utils.state_management import (
     initialize_session_state,
@@ -25,6 +24,10 @@ from src.ui.utils.state_management import (
 from src.core.coding import DesignSpace
 from src.core.factors import Factor
 from src.ui.utils.csv_parser import generate_doe_csv
+from src.ui.utils.response_definitions import (
+    validate_response_name,
+    response_rows_to_definitions,
+)
 from src.ui.components.constraint_builder import (
     format_constraint_preview,
     validate_constraints
@@ -32,29 +35,7 @@ from src.ui.components.constraint_builder import (
 
 
 def _validate_response_name(name: str, existing_responses: list) -> bool:
-    """
-    Validate response name.
-    
-    Rules:
-    - Must be alphanumeric + underscore
-    - Must not be duplicate (case-insensitive)
-    - Must not be reserved word
-    """
-    # Check format
-    if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', name):
-        return False
-    
-    # Check for duplicates (case-insensitive)
-    existing_names = [r['name'].lower() for r in existing_responses]
-    if name.lower() in existing_names:
-        return False
-    
-    # Check for reserved words
-    reserved = {'I', 'C', 'Q', 'T'}  # patsy/pandas reserved
-    if name in reserved:
-        return False
-    
-    return True
+    return validate_response_name(name, existing_responses)
 
 
 # Initialize state
@@ -93,88 +74,91 @@ if st.session_state.get('design') is None:
     
     response_defs = st.session_state['response_definitions']
     
-    # Response definition form
-    with st.form("response_form", border=True):
-        # Container for response rows
-        response_rows = []
-        
-        # Show existing responses with option to edit/remove
-        for i, response in enumerate(response_defs):
-            col1, col2, col3 = st.columns([2, 1.5, 0.5])
-            
-            with col1:
-                response_rows.append({
-                    'name': st.text_input(
-                        "Response Name",
-                        value=response.get('name', ''),
-                        key=f"response_name_{i}",
-                        label_visibility="collapsed"
-                    ),
-                    'index': i
-                })
-            
-            with col2:
-                units = st.text_input(
-                    "Units",
-                    value=response.get('units', '') if response.get('units') else '',
-                    key=f"response_units_{i}",
-                    placeholder="e.g., %, mg/mL",
-                    label_visibility="collapsed"
-                )
-                response_rows[i]['units'] = units if units else None
-            
-            with col3:
-                if st.form_submit_button(
-                    "❌",
-                    key=f"remove_response_{i}",
-                    help="Remove this response"
-                ):
-                    st.session_state['response_definitions'].pop(i)
-                    st.rerun()
-        
-        # Add new empty row for adding response
-        col1, col2, col3 = st.columns([2, 1.5, 0.5])
-        
-        with col1:
-            new_name = st.text_input(
-                "Response Name",
-                value='',
-                key="response_name_new",
-                label_visibility="collapsed"
-            )
-        
-        with col2:
-            new_units = st.text_input(
-                "Units",
-                value='',
-                key="response_units_new",
-                placeholder="e.g., %, mg/mL",
-                label_visibility="collapsed"
-            )
-        
-        col_left, col_right = st.columns([2.5, 1])
-        
-        with col_right:
-            if st.form_submit_button("+ Add Response", width='stretch'):
-                if new_name.strip():
-                    # Validate response name
-                    if not _validate_response_name(new_name, st.session_state['response_definitions']):
-                        st.error("Response name invalid or already exists")
-                    else:
-                        st.session_state['response_definitions'].append({
-                            'name': new_name.strip(),
-                            'units': new_units.strip() if new_units.strip() else None
-                        })
-                        st.rerun()
+    st.info(
+        "💡 **Quick Tips:**\n"
+        "- Use the **+ button at the bottom** of the table to add new responses\n"
+        "- Add or remove rows directly in the table (like the factors grid)\n"
+        "- Names with spaces, parentheses, etc. are **auto-cleaned** to be formula-safe "
+        "(e.g., `Day 0 Max Force (g)` → `Day_0_Max_Force_g`)"
+    )
+
+    # Editable table of responses (JMP-style, mirrors the factors grid)
+    def responses_to_dataframe(response_defs) -> pd.DataFrame:
+        """Convert response definitions to an editable DataFrame."""
+        if not response_defs:
+            return pd.DataFrame({
+                'Name': pd.Series([], dtype='str'),
+                'Units': pd.Series([], dtype='str')
+            })
+        return pd.DataFrame([
+            {'Name': str(r.get('name', '')), 'Units': str(r.get('units', '') or '')}
+            for r in response_defs
+        ])
+
+    response_column_config = {
+        'Name': st.column_config.TextColumn(
+            'Response Name',
+            help='Descriptive name (e.g., Max Force). Spaces/parentheses are '
+                 'auto-cleaned to be formula-safe.',
+            required=True,
+            max_chars=50
+        ),
+        'Units': st.column_config.TextColumn(
+            'Units',
+            help='Optional units (e.g., %, mg/mL)',
+            max_chars=20
+        )
+    }
+
+    edited_responses_df = st.data_editor(
+        responses_to_dataframe(response_defs),
+        column_config=response_column_config,
+        width='stretch',
+        num_rows='dynamic',  # Allow adding/deleting rows
+        key='response_table_editor'
+    )
+
+    st.divider()
+
+    # Action buttons
+    col1, col2 = st.columns([1, 1])
+
+    with col1:
+        if st.button("💾 Save Responses", type="primary", width='stretch'):
+            # Validate and save
+            with st.spinner("Validating responses..."):
+                defs, errors, warnings = response_rows_to_definitions(edited_responses_df)
+
+                if errors:
+                    st.error("**Validation Errors:**")
+                    for error in errors:
+                        st.error(f"• {error}")
                 else:
-                    st.warning("Response name cannot be empty")
-        
-        # Update existing responses from form input
-        for i, row in enumerate(response_rows):
-            if i < len(st.session_state['response_definitions']):
-                st.session_state['response_definitions'][i]['name'] = row['name']
-                st.session_state['response_definitions'][i]['units'] = row['units']
-    
+                    st.session_state['response_definitions'] = defs
+
+                    if warnings:
+                        with st.expander("⚠️ Response Name Sanitization", expanded=True):
+                            st.warning(
+                                f"**{len(warnings)} response name(s) were modified for compatibility:**"
+                            )
+                            for warning in warnings:
+                                st.markdown(f"**Row {warning['row']}:**")
+                                st.markdown(f"- Original: `{warning['original']}`")
+                                st.markdown(f"- Sanitized: `{warning['sanitized']}`")
+                                if warning['changes']:
+                                    with st.expander(f"Why was '{warning['original']}' changed?"):
+                                        for change in warning['changes']:
+                                            st.caption(f"• {change}")
+                    else:
+                        st.success(f"✅ Saved {len(defs)} response(s) successfully!")
+                    st.rerun()
+
+    with col2:
+        if len(response_defs) > 0:
+            if st.button("🗑️ Clear All Responses", width='stretch'):
+                st.session_state['response_definitions'] = []
+                st.rerun()
+
     # Show summary
     if st.session_state['response_definitions']:
         st.write(f"**Defined responses ({len(st.session_state['response_definitions'])}):**")

--- a/src/ui/pages/6_analyze.py
+++ b/src/ui/pages/6_analyze.py
@@ -40,6 +40,7 @@ from src.ui.components.diagnostics_display import display_diagnostics_tab
 from src.ui.components.lof_testing import display_lack_of_fit_test
 from src.ui.components.profiler_display import display_profiler_tab
 from src.ui.components.interaction_display import display_interaction_plot_tab
+from src.ui.components.box_plot_display import display_box_plot_tab
 from src.core.analysis import ANOVAAnalysis, generate_model_terms  # noqa: E402
 
 
@@ -345,9 +346,10 @@ _response_units_map = {
 _factor_units_map = {f.name: f.units for f in factors}
 current_response_units = _response_units_map.get(selected_response)
 
-tab1, tab2, tab3, tab4, tab5 = st.tabs([
+tab1, tab2, tab3, tab4, tab5, tab6 = st.tabs([
     "📊 Model Fit", "📉 Effects & Residuals",
-    "🔍 Design Diagnostics", "📈 Profiler", "🕸️ Interaction Plots"
+    "🔍 Design Diagnostics", "📈 Profiler", "🕸️ Interaction Plots",
+    "📦 Box Plots"
 ])
 
 with tab1:
@@ -757,6 +759,14 @@ with tab5:
         response=response_filtered,
         factors=factors,
         results=interaction_results,
+        response_units=current_response_units,
+    )
+with tab6:
+    display_box_plot_tab(
+        selected_response=selected_response,
+        design=design_filtered,
+        response=response_filtered,
+        factors=factors,
         response_units=current_response_units,
     )
 st.divider()

--- a/src/ui/pages/6_analyze.py
+++ b/src/ui/pages/6_analyze.py
@@ -237,21 +237,23 @@ if 'model_terms_per_response' not in st.session_state:
 if selected_response not in st.session_state['model_terms_per_response']:
     # Pre-populate from Step 2 if available, otherwise default to linear
     if 'model_terms' in st.session_state and st.session_state['model_terms']:
-        default_terms = st.session_state['model_terms']
+        default_terms = list(st.session_state['model_terms'])
         st.info("🎯 Using model selected in Step 2. You can modify it below if needed.")
     else:
         default_terms = generate_model_terms(factors, 'linear', include_intercept=True)
         st.info("ℹ️ No model was pre-selected. Defaulting to linear model. You can modify it below.")
     st.session_state['model_terms_per_response'][selected_response] = default_terms
 
-current_terms = st.session_state['model_terms_per_response'][selected_response]
+current_terms = list(st.session_state['model_terms_per_response'][selected_response])
 
 updated_terms = display_model_builder(
     factors=factors, current_terms=current_terms, response_name=selected_response,
     key_prefix=f"model_builder_{selected_response}"
 )
 
-# Force update if terms changed
+# Force update if terms changed. The builder may either mutate the list it was
+# given in place or return a whole new list; compare by value so both cases are
+# caught and trigger a refit.
 if updated_terms != current_terms:
     st.session_state['model_terms_per_response'][selected_response] = updated_terms
     invalidate_downstream_state(from_step=5)

--- a/src/ui/pages/6_analyze.py
+++ b/src/ui/pages/6_analyze.py
@@ -29,6 +29,8 @@ from src.ui.utils.plotting import (
     create_parity_plot,
     create_residual_plot,
     create_logworth_plot,
+    create_coefficient_significance_plot,
+    create_standardized_effects_plot,
     create_qq_plot,
     create_half_normal_plot,
     _label_with_units,
@@ -390,17 +392,108 @@ with tab1:
         st.plotly_chart(fig, width='stretch')
     
     st.divider()
-    
-    st.markdown("**Effect Significance (Pareto)**")
-    if not results.logworth.empty:
-        p_values = {}
-        for term in results.logworth.index:
-            p_val = 10 ** (-results.logworth.loc[term, 'LogWorth'])
-            p_values[term] = p_val
-        
-        fig = create_logworth_plot(results.logworth, p_values)
-        st.plotly_chart(fig, width='stretch')
-    
+
+    # --- Effect significance: coefficient-level LogWorth vs ANOVA effects ---
+    _has_coef = (
+        results.coefficient_significance is not None
+        and not results.coefficient_significance.empty
+    )
+    _has_anova_effects = (
+        results.anova_effect_summary is not None
+        and not results.anova_effect_summary.empty
+    )
+
+    if _has_coef or _has_anova_effects or not results.logworth.empty:
+        st.markdown("## Effect Significance")
+        view = st.segmented_control(
+            "Effect chart view",
+            options=["**Side-by-Side**", "**Coefficient LogWorth**", "**DOE Standardized Effects**"],
+            default="**Side-by-Side**",
+            selection_mode="single",
+            label_visibility="collapsed",
+        )
+        show_block = st.checkbox(
+            "Show block/design terms",
+            value=True,
+            help="Controls display only; hiding block terms does not refit the model.",
+        )
+        st.caption(
+            "Coefficient LogWorth summarizes individual fitted coefficients. "
+            "DOE standardized effects summarize term-level ANOVA tests. "
+            "The results can differ for categorical, blocked, split-plot, "
+            "hierarchical, and interaction models."
+        )
+
+        def _coef_fig():
+            if _has_coef:
+                return create_coefficient_significance_plot(
+                    results.coefficient_significance, alpha=0.05, show_block=show_block
+                )
+            if not results.logworth.empty:
+                p_values = {
+                    term: 10 ** (-results.logworth.loc[term, 'LogWorth'])
+                    for term in results.logworth.index
+                }
+                return create_logworth_plot(results.logworth, p_values)
+            return None
+
+        def _anova_fig():
+            if _has_anova_effects:
+                return create_standardized_effects_plot(
+                    results.anova_effect_summary, alpha=0.05, show_block=show_block
+                )
+            return None
+
+        _effects_caption = (
+            "Bar color — blue: positive effect · red: negative effect · "
+            "gray: multi-df or block/design term. "
+            "Lines (shown when a single error stratum applies) — "
+            "dashed: t-critical at α=0.05 · dotted: Bonferroni limit (α/m)."
+        )
+
+        def _shared_height():
+            n = 0
+            if _has_coef:
+                n = max(n, len(results.coefficient_significance))
+            if _has_anova_effects:
+                n = max(n, len(results.anova_effect_summary))
+            return max(320, n * 26)
+
+        if view == "**Side-by-Side**":
+            c1, c2 = st.columns(2)
+            with c1:
+                fig = _coef_fig()
+                if fig is not None:
+                    st.plotly_chart(
+                        fig, width='stretch', height=_shared_height(), theme=None
+                    )
+            with c2:
+                fig = _anova_fig()
+                if fig is not None:
+                    st.plotly_chart(
+                        fig, width='stretch', height=_shared_height(), theme=None
+                    )
+                    st.caption(_effects_caption)
+                else:
+                    st.info(
+                        "ANOVA-based standardized effects are only available "
+                        "for models with a term-level ANOVA table."
+                    )
+        elif view == "**Coefficient LogWorth**":
+            fig = _coef_fig()
+            if fig is not None:
+                st.plotly_chart(fig, width='stretch', theme=None)
+        else:
+            fig = _anova_fig()
+            if fig is not None:
+                st.plotly_chart(fig, width='stretch', theme=None)
+                st.caption(_effects_caption)
+            else:
+                st.info(
+                    "ANOVA-based standardized effects are only available "
+                    "for models with a term-level ANOVA table."
+                )
+
     st.divider()
     
     st.markdown("**ANOVA Table**")

--- a/src/ui/pages/6_analyze.py
+++ b/src/ui/pages/6_analyze.py
@@ -37,6 +37,7 @@ from src.ui.components.model_builder import display_model_builder, format_term_f
 from src.ui.components.diagnostics_display import display_diagnostics_tab
 from src.ui.components.lof_testing import display_lack_of_fit_test
 from src.ui.components.profiler_display import display_profiler_tab
+from src.ui.components.interaction_display import display_interaction_plot_tab
 from src.core.analysis import ANOVAAnalysis, generate_model_terms  # noqa: E402
 
 
@@ -340,9 +341,9 @@ _response_units_map = {
 _factor_units_map = {f.name: f.units for f in factors}
 current_response_units = _response_units_map.get(selected_response)
 
-tab1, tab2, tab3, tab4 = st.tabs([
+tab1, tab2, tab3, tab4, tab5 = st.tabs([
     "📊 Model Fit", "📉 Effects & Residuals",
-    "🔍 Design Diagnostics", "📈 Profiler"
+    "🔍 Design Diagnostics", "📈 Profiler", "🕸️ Interaction Plots"
 ])
 
 with tab1:
@@ -645,6 +646,22 @@ with tab4:
         results=results,
         factors=factors,
         format_term_for_display=format_term_for_display,
+        response_units=current_response_units,
+    )
+with tab5:
+    # Interaction plots require a fitted model for the significance overlay.
+    if selected_response not in st.session_state['fitted_models']:
+        st.warning("Please fit a model first")
+        st.stop()
+
+    interaction_results = st.session_state['fitted_models'][selected_response]
+
+    display_interaction_plot_tab(
+        selected_response=selected_response,
+        design=design_filtered,
+        response=response_filtered,
+        factors=factors,
+        results=interaction_results,
         response_units=current_response_units,
     )
 st.divider()

--- a/src/ui/pages/8_optimize.py
+++ b/src/ui/pages/8_optimize.py
@@ -130,6 +130,7 @@ if optimization_mode == 'single':
     st.markdown("**Factor Constraints**")
 
     factor_constraints = {}
+    pinned_levels = {}
     for factor in factors:
         if factor.is_continuous():
             col1, col2 = st.columns(2)
@@ -150,6 +151,19 @@ if optimization_mode == 'single':
 
             factor_constraints[factor.name] = (min_val, max_val)
 
+        elif factor.is_categorical():
+            # The optimizer can pick the best level (default), or the user can
+            # pin the level by selecting one explicitly.
+            level_choice = st.selectbox(
+                f"{factor.name} level",
+                ["(Optimize — choose best level)"] + list(factor.levels),
+                key=f'cat_{factor.name}',
+                help="Leave as '(Optimize)' to let the optimizer select the "
+                     "level that maximizes/minimizes the response."
+            )
+            if level_choice != "(Optimize — choose best level)":
+                pinned_levels[factor.name] = level_choice
+
     # Optimize button
     if st.button("🔍 Find Optimal Settings", type="primary", width='stretch'):
         with st.spinner("Optimizing..."):
@@ -169,6 +183,7 @@ if optimization_mode == 'single':
                     bounds=factor_constraints if factor_constraints else None,
                     seed=42,
                     model_is_coded=_model_is_coded,
+                    pinned_levels=pinned_levels if pinned_levels else None,
                 )
 
                 if opt_result.success:
@@ -230,7 +245,9 @@ if optimization_mode == 'single':
                     st.subheader("Optimal Factor Settings")
                     for fname, value in opt_result.optimal_settings.items():
                         factor = next(f for f in factors if f.name == fname)
-                        if factor.units:
+                        if factor.is_categorical():
+                            st.metric(fname, str(value))
+                        elif factor.units:
                             st.metric(fname, f"{value:.3f} {factor.units}")
                         else:
                             st.metric(fname, f"{value:.3f}")
@@ -344,6 +361,7 @@ elif optimization_mode == 'desirability':
         st.divider()
 
         # --- Factor bounds ---
+        pinned_levels_d: Dict[str, object] = {}
         with st.expander("🔧 Factor Bounds (optional)"):
             factor_bounds_d: Dict[str, tuple] = {}
             for factor in factors:
@@ -362,6 +380,17 @@ elif optimization_mode == 'desirability':
                             key=f'dmax_{factor.name}'
                         )
                     factor_bounds_d[factor.name] = (bmin, bmax)
+
+                elif factor.is_categorical():
+                    level_choice = st.selectbox(
+                        f"{factor.name} level",
+                        ["(Optimize — choose best level)"] + list(factor.levels),
+                        key=f'dcat_{factor.name}',
+                        help="Leave as '(Optimize)' to let the optimizer select "
+                             "the best level across all responses."
+                    )
+                    if level_choice != "(Optimize — choose best level)":
+                        pinned_levels_d[factor.name] = level_choice
 
         # --- Validate config before allowing run ---
         config_errors: List[str] = []
@@ -422,6 +451,7 @@ elif optimization_mode == 'desirability':
                         bounds=factor_bounds_d if factor_bounds_d else None,
                         seed=42,
                         model_is_coded=_model_is_coded,
+                        pinned_levels=pinned_levels_d if pinned_levels_d else None,
                     )
 
                     # Store result for profile tab
@@ -443,9 +473,14 @@ elif optimization_mode == 'desirability':
                         val = d_result.optimal_settings.get(factor.name)
                         if val is not None:
                             label = f"{factor.name} ({factor.units})" if factor.units else factor.name
-                            settings_cols[idx % len(settings_cols)].metric(
-                                label, f"{val:.3f}"
-                            )
+                            if factor.is_categorical():
+                                settings_cols[idx % len(settings_cols)].metric(
+                                    label, str(val)
+                                )
+                            else:
+                                settings_cols[idx % len(settings_cols)].metric(
+                                    label, f"{val:.3f}"
+                                )
 
                     st.divider()
 
@@ -465,7 +500,7 @@ elif optimization_mode == 'desirability':
                         })
 
                     results_df = pd.DataFrame(results_rows)
-                    st.dataframe(results_df, hide_index=True, use_container_width=True)
+                    st.dataframe(results_df, hide_index=True, width="stretch")
 
                     # Overall desirability — prominent display
                     st.metric(
@@ -524,7 +559,7 @@ elif optimization_mode == 'desirability':
                 annotation_text=f"Overall D = {d_result.overall_desirability:.3f}",
                 annotation_position='top right'
             )
-            st.plotly_chart(fig_bar, use_container_width=True)
+            st.plotly_chart(fig_bar, width="stretch")
 
             # Desirability summary table
             st.subheader("Summary at Optimal Settings")
@@ -543,7 +578,7 @@ elif optimization_mode == 'desirability':
             st.dataframe(
                 pd.DataFrame(summary_rows),
                 hide_index=True,
-                use_container_width=True
+                width="stretch"
             )
 
             st.metric(

--- a/src/ui/pages/8_optimize.py
+++ b/src/ui/pages/8_optimize.py
@@ -132,7 +132,7 @@ if optimization_mode == 'single':
     factor_constraints = {}
     pinned_levels = {}
     for factor in factors:
-        if factor.is_continuous():
+        if factor.is_continuous() or factor.is_discrete_numeric():
             col1, col2 = st.columns(2)
 
             with col1:
@@ -365,7 +365,7 @@ elif optimization_mode == 'desirability':
         with st.expander("🔧 Factor Bounds (optional)"):
             factor_bounds_d: Dict[str, tuple] = {}
             for factor in factors:
-                if factor.is_continuous():
+                if factor.is_continuous() or factor.is_discrete_numeric():
                     bc1, bc2 = st.columns(2)
                     with bc1:
                         bmin = st.number_input(

--- a/src/ui/pages/8_optimize.py
+++ b/src/ui/pages/8_optimize.py
@@ -57,6 +57,32 @@ if not fitted_models:
     st.error("No fitted models available. Please complete analysis in Step 5.")
     st.stop()
 
+# Mode and response selection (below the page title)
+# Use CSV column order; only include responses that have been fitted.
+all_response_names = st.session_state.get('response_names', [])
+response_names = [rn for rn in all_response_names if rn in fitted_models]
+
+if len(response_names) == 1:
+    optimization_mode = 'single'
+    primary_response = response_names[0]
+else:
+    optimization_mode = st.radio(
+        "Optimization Mode",
+        ["Single Response", "Desirability Function"],
+        horizontal=True,
+        key='opt_mode'
+    )
+
+    if optimization_mode == "Single Response":
+        optimization_mode = 'single'
+        primary_response = st.selectbox(
+            "Response to Optimize",
+            response_names
+        )
+    else:
+        optimization_mode = 'desirability'
+        primary_response = None
+
 # Show design status
 if is_using_augmented_design():
     augmented = st.session_state['augmented_design']
@@ -75,37 +101,6 @@ if is_using_augmented_design():
             st.metric("Augmented Runs", phase_counts.get(2, 0))
 
 st.divider()
-
-# Sidebar: Optimization settings
-st.sidebar.header("Optimization Settings")
-
-response_names = list(fitted_models.keys())
-
-if len(response_names) == 1:
-    st.sidebar.markdown("**Single Response Optimization**")
-    optimization_mode = 'single'
-    primary_response = response_names[0]
-else:
-    st.sidebar.markdown("**Multi-Response Optimization**")
-    optimization_mode = st.sidebar.radio(
-        "Mode",
-        ["Single Response", "Desirability Function"],
-        key='opt_mode'
-    )
-    
-    if optimization_mode == "Single Response":
-        optimization_mode = 'single'
-        primary_response = st.sidebar.selectbox(
-            "Response to Optimize",
-            response_names
-        )
-    else:
-        optimization_mode = 'desirability'
-        primary_response = None
-
-# Main content tabs
-if optimization_mode != 'single':
-    tab1, tab2 = st.tabs(["🎯 Multi-Response Optimization", "📈 Desirability Profile"])
 
 # Single Response: render content directly
 if optimization_mode == 'single':
@@ -277,92 +272,119 @@ if optimization_mode == 'single':
 
 # Multi-response optimization
 elif optimization_mode == 'desirability':
-    with tab1:
-        st.subheader("Multi-Response Optimization via Desirability")
+    st.subheader("Multi-Response Optimization via Desirability")
 
-        st.info(
-            "Configure a desirability goal for each response. "
-            "The optimizer maximizes overall desirability — the geometric mean of "
-            "individual desirabilities — to find factor settings that satisfy all "
-            "response objectives simultaneously."
-        )
+    st.info(
+        "Configure a desirability goal for each response below. "
+        "Only responses that have been fitted in Step 6 (Analyze) appear here, "
+        "in CSV column order. Set Goal to 'None' to track a response without "
+        "optimizing it.\n\n"
+        "The optimizer maximizes overall desirability — the geometric mean of "
+        "individual desirabilities — to find factor settings that satisfy all "
+        "response objectives simultaneously."
+    )
 
-        # --- Per-response desirability configuration ---
-        desirability_config: Dict[str, Dict] = {}
+    # --- Per-response desirability configuration (top of page) ---
+    desirability_config: Dict[str, Dict] = {}
+    responses_data = st.session_state.get('responses', {})
 
-        for response_name in response_names:
-            with st.expander(f"⚙️ Configure: {response_name}", expanded=True):
-                col_goal, col_imp = st.columns([2, 1])
+    for response_name in response_names:
+        with st.expander(f"Configure: {response_name}", expanded=True):
+            col_goal, col_imp = st.columns([2, 1])
 
-                with col_goal:
-                    goal = st.selectbox(
-                        "Goal",
-                        ["Maximize", "Minimize", "Target"],
-                        key=f'goal_{response_name}'
-                    )
-
-                with col_imp:
-                    importance = st.slider(
-                        "Importance",
-                        min_value=1,
-                        max_value=5,
-                        value=3,
-                        key=f'importance_{response_name}',
-                        help="Relative importance in geometric mean (1=low, 5=critical)"
-                    )
-
-                col_lo, col_hi = st.columns(2)
-
-                with col_lo:
-                    low_val = st.number_input(
-                        "Low (d=0)" if goal == "Maximize" else
-                        "Low (d=1)" if goal == "Minimize" else
-                        "Low (d=0)",
-                        value=0.0,
-                        key=f'low_{response_name}'
-                    )
-
-                with col_hi:
-                    high_val = st.number_input(
-                        "High (d=1)" if goal == "Maximize" else
-                        "High (d=0)" if goal == "Minimize" else
-                        "High (d=0)",
-                        value=1.0,
-                        key=f'high_{response_name}'
-                    )
-
-                target_val: float = 0.0
-                if goal == "Target":
-                    target_val = st.number_input(
-                        "Target (d=1)",
-                        value=(low_val + high_val) / 2,
-                        key=f'target_{response_name}'
-                    )
-
-                weight_val = st.slider(
-                    "Weight (shape)",
-                    min_value=0.1,
-                    max_value=5.0,
-                    value=1.0,
-                    step=0.1,
-                    key=f'weight_{response_name}',
-                    help="1=linear ramp, >1=emphasize target, <1=more tolerant"
+            with col_goal:
+                goal = st.selectbox(
+                    "Goal",
+                    ["None", "Maximize", "Minimize", "Target"],
+                    key=f'goal_{response_name}'
                 )
 
-                desirability_config[response_name] = {
-                    'goal': goal,
-                    'low': low_val,
-                    'high': high_val,
-                    'target': target_val,
-                    'weight': weight_val,
-                    'importance': float(importance)
-                }
+            with col_imp:
+                importance = st.slider(
+                    "Importance",
+                    min_value=1,
+                    max_value=5,
+                    value=3,
+                    key=f'importance_{response_name}',
+                    help="Relative importance in geometric mean (1=low, 5=critical)"
+                )
 
-        st.divider()
+            col_lo, col_hi = st.columns(2)
 
+            # Sensible default limits from the measured response range so the
+            # desirability ramp is meaningful (otherwise d is flat when the
+            # response scale is far from the default 0/1).
+            _rdata = responses_data.get(response_name)
+            if _rdata is not None and len(_rdata) > 0:
+                _rmin = float(np.nanmin(_rdata))
+                _rmax = float(np.nanmax(_rdata))
+            else:
+                _rmin, _rmax = 0.0, 1.0
+
+            with col_lo:
+                low_val = st.number_input(
+                    "Low (d=0)" if goal == "Maximize" else
+                    "Low (d=1)" if goal == "Minimize" else
+                    "Low (d=0)" if goal == "Target" else
+                    "Lower Limit",
+                    value=_rmin,
+                    key=f'low_{response_name}'
+                )
+
+            with col_hi:
+                high_val = st.number_input(
+                    "High (d=1)" if goal == "Maximize" else
+                    "High (d=0)" if goal == "Minimize" else
+                    "High (d=0)" if goal == "Target" else
+                    "Upper Limit",
+                    value=_rmax,
+                    key=f'high_{response_name}'
+                )
+
+            target_val: float = 0.0
+            if goal == "Target":
+                target_val = st.number_input(
+                    "Target (d=1)",
+                    value=(low_val + high_val) / 2,
+                    key=f'target_{response_name}'
+                )
+
+            weight_val = st.slider(
+                "Weight (shape)",
+                min_value=0.1,
+                max_value=5.0,
+                value=1.0,
+                step=0.1,
+                key=f'weight_{response_name}',
+                help="1=linear ramp, >1=emphasize target, <1=more tolerant"
+            )
+
+            desirability_config[response_name] = {
+                'goal': goal,
+                'low': low_val,
+                'high': high_val,
+                'target': target_val,
+                'weight': weight_val,
+                'importance': float(importance)
+            }
+
+    # Note about unfitted responses
+    unfitted = [rn for rn in all_response_names if rn not in fitted_models]
+    if unfitted:
+        st.caption(
+            "⚠️ Not yet analyzed (go to Step 6 to fit): "
+            + ", ".join(unfitted)
+        )
+
+    st.divider()
+
+    # --- Tabs: Factor Bounds + Optimize | Desirability Profile ---
+    tab1, tab2 = st.tabs(["Multi-Response Optimization", "Desirability Profile"])
+
+    with tab1:
         # --- Factor bounds ---
         pinned_levels_d: Dict[str, object] = {}
-        with st.expander("🔧 Factor Bounds (optional)"):
+        with st.expander("Factor Bounds (optional)"):
             factor_bounds_d: Dict[str, tuple] = {}
             for factor in factors:
                 if factor.is_continuous() or factor.is_discrete_numeric():
@@ -395,15 +417,27 @@ elif optimization_mode == 'desirability':
         # --- Validate config before allowing run ---
         config_errors: List[str] = []
         for rn, cfg in desirability_config.items():
-            if cfg['low'] >= cfg['high']:
-                config_errors.append(
-                    f"{rn}: Low must be less than High."
-                )
-            if cfg['goal'] == 'Target':
-                if not (cfg['low'] < cfg['target'] < cfg['high']):
+            if cfg['goal'] != 'None':
+                if cfg['low'] >= cfg['high']:
                     config_errors.append(
-                        f"{rn}: Target must be strictly between Low and High."
+                        f"{rn}: Low must be less than High."
                     )
+                if cfg['goal'] == 'Target':
+                    if not (cfg['low'] < cfg['target'] < cfg['high']):
+                        config_errors.append(
+                            f"{rn}: Target must be strictly between Low and High."
+                        )
+
+        # Guard against nothing to optimize (all responses set to "None")
+        active_responses = [
+            rn for rn in response_names
+            if desirability_config[rn]['goal'] != 'None'
+        ]
+        if not active_responses:
+            config_errors.append(
+                "Set at least one response to Maximize, Minimize, or Target — "
+                "with all responses set to 'None' there is nothing to optimize."
+            )
 
         if config_errors:
             for err in config_errors:
@@ -412,7 +446,7 @@ elif optimization_mode == 'desirability':
         run_disabled = bool(config_errors)
 
         if st.button(
-            "🔍 Find Optimal Settings",
+            "Find Optimal Settings",
             type="primary",
             disabled=run_disabled,
             key='run_desirability'
@@ -424,10 +458,12 @@ elif optimization_mode == 'desirability':
                         optimize_desirability
                     )
 
-                    # Build DesirabilityFunction
-                    d_func = DesirabilityFunction(response_names)
+                    # Only add responses with an actual goal to desirability
+                    # (active_responses already computed above for validation)
+                    d_func = DesirabilityFunction(active_responses)
 
-                    for rn, cfg in desirability_config.items():
+                    for rn in active_responses:
+                        cfg = desirability_config[rn]
                         goal_map = {
                             'Maximize': 'maximize',
                             'Minimize': 'minimize',
@@ -443,7 +479,7 @@ elif optimization_mode == 'desirability':
                             importance=cfg['importance']
                         )
 
-                    # Run optimizer
+                    # Run optimizer (passes all fitted models for prediction)
                     d_result = optimize_desirability(
                         anova_results_dict=fitted_models,
                         factors=factors,
@@ -459,10 +495,10 @@ elif optimization_mode == 'desirability':
                     st.session_state['desirability_config'] = desirability_config
 
                     if d_result.success:
-                        st.success("✅ Optimal settings found!")
+                        st.success("Optimal settings found!")
                     else:
                         st.warning(
-                            f"⚠️ Optimizer did not fully converge: {d_result.message}. "
+                            f"Optimizer did not fully converge: {d_result.message}. "
                             "Results may still be useful."
                         )
 
@@ -489,14 +525,15 @@ elif optimization_mode == 'desirability':
 
                     results_rows = []
                     for rn in response_names:
+                        goal = desirability_config[rn]['goal']
                         results_rows.append({
                             'Response': rn,
                             'Predicted': round(d_result.predicted_responses[rn], 4),
-                            'Desirability (dᵢ)': round(
+                            'Desirability (d)': '—' if goal == 'None' else round(
                                 d_result.individual_desirabilities[rn], 4
                             ),
-                            'Goal': desirability_config[rn]['goal'],
-                            'Importance': int(desirability_config[rn]['importance'])
+                            'Goal': goal,
+                            'Importance': '—' if goal == 'None' else int(desirability_config[rn]['importance'])
                         })
 
                     results_df = pd.DataFrame(results_rows)
@@ -510,7 +547,7 @@ elif optimization_mode == 'desirability':
                              "D=1 is ideal; D=0 means at least one response is unacceptable."
                     )
 
-                    with st.expander("🔍 Optimization Details"):
+                    with st.expander("Optimization Details"):
                         st.write(f"**Iterations:** {d_result.n_iterations}")
                         st.write(f"**Status:** {d_result.message}")
 
@@ -529,51 +566,60 @@ elif optimization_mode == 'desirability':
         else:
             import plotly.graph_objects as go
 
-            # Individual desirability bar chart
-            resp_labels = list(d_result.individual_desirabilities.keys())
+            # Individual desirability bar chart (exclude "None" goal responses)
+            resp_labels = [
+                rn for rn in d_result.individual_desirabilities
+                if d_config.get(rn, {}).get('goal', 'None') != 'None'
+            ]
             d_values = [d_result.individual_desirabilities[r] for r in resp_labels]
 
-            bar_colors = [
-                '#2ecc71' if v >= 0.8 else '#f39c12' if v >= 0.5 else '#e74c3c'
-                for v in d_values
-            ]
+            if resp_labels:
+                bar_colors = [
+                    '#2ecc71' if v >= 0.8 else '#f39c12' if v >= 0.5 else '#e74c3c'
+                    for v in d_values
+                ]
 
-            fig_bar = go.Figure(go.Bar(
-                x=resp_labels,
-                y=d_values,
-                marker_color=bar_colors,
-                text=[f"{v:.3f}" for v in d_values],
-                textposition='outside'
-            ))
-            fig_bar.update_layout(
-                title="Individual Desirabilities",
-                yaxis=dict(range=[0, 1.1], title="Desirability"),
-                xaxis_title="Response",
-                showlegend=False,
-                height=350
-            )
-            fig_bar.add_hline(
-                y=d_result.overall_desirability,
-                line_dash='dash',
-                line_color='navy',
-                annotation_text=f"Overall D = {d_result.overall_desirability:.3f}",
-                annotation_position='top right'
-            )
-            st.plotly_chart(fig_bar, width="stretch")
+                fig_bar = go.Figure(go.Bar(
+                    x=resp_labels,
+                    y=d_values,
+                    marker_color=bar_colors,
+                    text=[f"{v:.3f}" for v in d_values],
+                    textposition='outside'
+                ))
+                fig_bar.update_layout(
+                    title="Individual Desirabilities",
+                    yaxis=dict(range=[0, 1.1], title="Desirability"),
+                    xaxis_title="Response",
+                    showlegend=False,
+                    height=350
+                )
+                fig_bar.add_hline(
+                    y=d_result.overall_desirability,
+                    line_dash='dash',
+                    line_color='navy',
+                    annotation_text=f"Overall D = {d_result.overall_desirability:.3f}",
+                    annotation_position='top right'
+                )
+                st.plotly_chart(fig_bar, width="stretch")
+            else:
+                st.info("No responses with desirability goals to chart (all set to 'None').")
 
-            # Desirability summary table
+            # Desirability summary table (all responses, including "None")
             st.subheader("Summary at Optimal Settings")
             summary_rows = []
-            for rn in resp_labels:
+            for rn in response_names:
+                if rn not in d_result.predicted_responses:
+                    continue
                 cfg = d_config.get(rn, {})
+                goal = cfg.get('goal', 'None')
                 summary_rows.append({
                     'Response': rn,
-                    'Goal': cfg.get('goal', '—'),
+                    'Goal': goal,
                     'Low': cfg.get('low', '—'),
                     'High': cfg.get('high', '—'),
-                    'Target': cfg.get('target', '—') if cfg.get('goal') == 'Target' else '—',
+                    'Target': cfg.get('target', '—') if goal == 'Target' else '—',
                     'Predicted': round(d_result.predicted_responses[rn], 4),
-                    'dᵢ': round(d_result.individual_desirabilities[rn], 4)
+                    'd': '—' if goal == 'None' else round(d_result.individual_desirabilities.get(rn, 0), 4)
                 })
             st.dataframe(
                 pd.DataFrame(summary_rows),

--- a/src/ui/utils/csv_parser.py
+++ b/src/ui/utils/csv_parser.py
@@ -82,7 +82,7 @@ def parse_doe_csv(file_content: str) -> ParseResult:
         factors = extract_factor_definitions(lines)
         response_definitions = extract_response_definitions(lines)
         model_terms = extract_model_terms(lines)
-        design_data = extract_design_data(lines)
+        design_data = extract_design_data(lines, factors)
 
         return ParseResult(
             metadata=metadata,
@@ -458,7 +458,10 @@ def extract_model_terms(lines: List[str]) -> Dict[str, List[str]]:
     return model_terms
 
 
-def extract_design_data(lines: List[str]) -> pd.DataFrame:
+def extract_design_data(
+    lines: List[str],
+    factors: Optional[List["Factor"]] = None
+) -> pd.DataFrame:
     """
     Extract design data section (after # DESIGN DATA).
 
@@ -466,6 +469,10 @@ def extract_design_data(lines: List[str]) -> pd.DataFrame:
     ----------
     lines : List[str]
         Raw CSV lines.
+    factors : Optional[List[Factor]]
+        Parsed factor definitions, used to protect categorical factor
+        columns from being coerced to numeric (e.g. categorical levels
+        that happen to be numeric-looking).
 
     Returns
     -------
@@ -508,18 +515,33 @@ def extract_design_data(lines: List[str]) -> pd.DataFrame:
     if design_data.empty:
         raise CSVParseError("DESIGN DATA section empty")
 
+    # Never coerce categorical factor columns to numeric. Categorical levels
+    # may be numeric-looking labels (e.g. batch/lot IDs) and must remain
+    # strings so patsy treats them as categorical in the ANOVA.
+    categorical_cols: set = set()
+    if factors:
+        categorical_cols = {
+            f.name for f in factors if f.factor_type == FactorType.CATEGORICAL
+        }
+
     # Convert numeric columns properly (handle % symbols and strings)
     for col in design_data.columns:
         # Skip metadata columns
         if col in ['StdOrder', 'RunOrder', 'Block', 'WholePlot', 'Phase']:
             continue
+        if col in categorical_cols:
+            continue
         
         # Try to convert to numeric, handling percentage symbols
         if design_data[col].dtype == object:
             try:
-                # Remove % symbols if present and convert
+                # Remove % symbols if present and convert. Only promote the
+                # column to numeric if every value parses; otherwise leave the
+                # original (e.g. a text/categorical column we don't know about).
                 cleaned = design_data[col].str.replace('%', '', regex=False)
-                design_data[col] = pd.to_numeric(cleaned, errors='ignore')
+                converted = pd.to_numeric(cleaned, errors='coerce')
+                if converted.notna().all():
+                    design_data[col] = converted
             except (AttributeError, ValueError):
                 # Not a string column or conversion failed - leave as is
                 pass

--- a/src/ui/utils/csv_parser.py
+++ b/src/ui/utils/csv_parser.py
@@ -450,7 +450,15 @@ def extract_model_terms(lines: List[str]) -> Dict[str, List[str]]:
 
         response_name, _, terms_str = content.partition(",")
         response_name = response_name.strip()
-        terms = [t.strip() for t in terms_str.split("|") if t.strip()]
+        # Excel re-saving can pad metadata lines with trailing commas. Those can
+        # get trapped inside the last pipe-delimited field (e.g. "Mud,,,,,"), so
+        # strip stray leading/trailing commas from each term — a comma is never
+        # a valid character in a patsy factor name or model term.
+        terms = [
+            t.strip().strip(',')
+            for t in terms_str.split("|")
+            if t.strip().strip(',')
+        ]
 
         if response_name and terms:
             model_terms[response_name] = terms

--- a/src/ui/utils/export.py
+++ b/src/ui/utils/export.py
@@ -182,7 +182,9 @@ def _build_model_fit_section(
         HTML string for this section.
     """
     from src.ui.utils.plotting import (
+        create_coefficient_significance_plot,
         create_logworth_plot,
+        create_standardized_effects_plot,
         create_parity_plot,
         create_residual_plot,
     )
@@ -237,8 +239,26 @@ def _build_model_fit_section(
             )
     parts.append("</div>")
 
-    # --- LogWorth Pareto ---
-    if results.logworth is not None and not results.logworth.empty:
+    # --- Coefficient LogWorth Pareto + ANOVA standardized effects ---
+    if results.coefficient_significance is not None and not results.coefficient_significance.empty:
+        try:
+            fig = create_coefficient_significance_plot(
+                results.coefficient_significance,
+                alpha=0.05,
+                show_block=True,
+            )
+            parts.append(
+                _plotly_div(
+                    fig,
+                    f"logworth_{response_name}",
+                    "Coefficient Significance (LogWorth)",
+                )
+            )
+        except Exception as exc:
+            parts.append(
+                f'<div class="plot-error">LogWorth plot failed: {exc}</div>'
+            )
+    elif results.logworth is not None and not results.logworth.empty:
         try:
             p_values = {
                 term: 10 ** (-results.logworth.loc[term, "LogWorth"])
@@ -249,12 +269,37 @@ def _build_model_fit_section(
                 _plotly_div(
                     fig,
                     f"logworth_{response_name}",
-                    "Effect Significance (Pareto / LogWorth)",
+                    "Coefficient Significance (LogWorth)",
                 )
             )
         except Exception as exc:
             parts.append(
                 f'<div class="plot-error">LogWorth plot failed: {exc}</div>'
+            )
+
+    if results.anova_effect_summary is not None and not results.anova_effect_summary.empty:
+        try:
+            fig = create_standardized_effects_plot(
+                results.anova_effect_summary,
+                alpha=0.05,
+                show_block=True,
+            )
+            parts.append(
+                _plotly_div(
+                    fig,
+                    f"effects_{response_name}",
+                    "DOE Pareto of Standardized Effects",
+                )
+            )
+            parts.append(
+                "<p class='muted'>Bar color — blue: positive effect · red: "
+                "negative effect · gray: multi-df or block/design term. "
+                "Dashed vertical line — t-critical at α=0.05; dotted vertical "
+                "line — Bonferroni limit (α/m).</p>"
+            )
+        except Exception as exc:
+            parts.append(
+                f'<div class="plot-error">Standardized effects plot failed: {exc}</div>'
             )
 
     # --- ANOVA table ---
@@ -748,7 +793,10 @@ def _build_optimization_section(response_name: str) -> str:
 
         if settings:
             rows = [
-                {"Factor": k, "Optimal Setting": f"{v:.4f}"}
+                {
+                    "Factor": k,
+                    "Optimal Setting": v if isinstance(v, str) else f"{v:.4f}",
+                }
                 for k, v in settings.items()
             ]
             parts.append(_df_to_html(pd.DataFrame(rows)))
@@ -813,7 +861,10 @@ def _build_optimization_section(response_name: str) -> str:
         settings = d_result.optimal_settings or {}
         if settings:
             rows = [
-                {"Factor": k, "Optimal Setting": f"{v:.4f}"}
+                {
+                    "Factor": k,
+                    "Optimal Setting": v if isinstance(v, str) else f"{v:.4f}",
+                }
                 for k, v in settings.items()
             ]
             parts.append(_df_to_html(pd.DataFrame(rows)))

--- a/src/ui/utils/plotting.py
+++ b/src/ui/utils/plotting.py
@@ -34,6 +34,21 @@ PLOT_COLORS: Dict[str, str] = {
     "sigma3": "#FF6347",  # Tomato red for 3σ
 }
 
+# Qualitative palette for categorical factor levels (one colour per line).
+# Mirrors the Plotly default 10-colour cycle so it stays consistent with the
+# rest of PLOT_COLORS.
+QUALITATIVE_COLORS: List[str] = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
+    "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf",
+]
+
+# Sequential palette for numeric factor levels, mapped by rank so the
+# gradient order always matches the numeric ordering of the levels.
+SEQUENTIAL_COLORS: List[str] = [
+    "#1f77b4", "#3182bd", "#6baed6", "#9ecae1",
+    "#fd8d3c", "#e6550d", "#d62728",
+]
+
 
 def apply_plot_style(fig: go.Figure) -> go.Figure:
     """
@@ -1162,5 +1177,299 @@ def create_3d_surface_plot(
         ),
         height=600,
     )
+
+    return apply_plot_style(fig)
+
+def interaction_stats(
+    f1_name: str,
+    f2_name: str,
+    design: pd.DataFrame,
+    response: np.ndarray,
+) -> pd.DataFrame:
+    """
+    Aggregate per-combination response statistics for an interaction plot.
+
+    For every observed combination of factor ``f1`` x ``f2`` this returns one
+    row with the mean response, sample standard deviation, replicate count,
+    standard error of the mean, and a 95% confidence interval for the mean.
+
+    Combinations with a missing (NaN) response are dropped; a combination with
+    a single replicate yields ``std = sem = 0`` and a CI collapsed to the mean.
+
+    Parameters
+    ----------
+    f1_name : str
+        Name of the x-axis factor column.
+    f2_name : str
+        Name of the line-encoding factor column.
+    design : pd.DataFrame
+        Design data (natural units) containing at least ``f1_name`` and
+        ``f2_name``.
+    response : np.ndarray
+        Response values aligned with ``design`` rows.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``[f1_name, f2_name, mean, std, n, sem, ci_lower, ci_upper]``.
+
+    Examples
+    --------
+    >>> stats = interaction_stats('A', 'B', design, response)
+    """
+    df = pd.DataFrame({
+        f1_name: np.asarray(design[f1_name].values),
+        f2_name: np.asarray(design[f2_name].values),
+        'response': np.asarray(response, dtype=float),
+    })
+    # Missing responses are excluded from the means.
+    df = df.dropna(subset=['response'])
+
+    grouped = df.groupby([f1_name, f2_name], sort=False)['response']
+    mean = grouped.mean().rename('mean').reset_index()
+    counts = grouped.size().rename('n').reset_index()
+    std = grouped.std(ddof=1).rename('std').reset_index()
+    sem = grouped.sem().rename('sem').reset_index()
+
+    result = mean.merge(counts, on=[f1_name, f2_name])
+    result = result.merge(std, on=[f1_name, f2_name])
+    result = result.merge(sem, on=[f1_name, f2_name])
+
+    result['mean'] = result['mean'].astype(float)
+    result['std'] = result['std'].fillna(0.0)
+    result['sem'] = result['sem'].fillna(0.0)
+    result['n'] = result['n'].astype(int)
+
+    # 95% CI for the mean using a t-distribution; with a single replicate
+    # there is no spread so the interval collapses onto the mean.
+    tcrit = np.where(
+        result['n'] > 1,
+        stats.t.ppf(0.975, df=np.clip(result['n'] - 1, 1, None)),
+        0.0,
+    )
+    result['ci_lower'] = result['mean'] - tcrit * result['sem']
+    result['ci_upper'] = result['mean'] + tcrit * result['sem']
+
+    return result
+
+
+def _sorted_levels(values, is_categorical: bool):
+    """Return the ordered set of level values for a factor column.
+
+    Categorical levels are sorted lexicographically to give a stable order;
+    numeric levels are sorted numerically so the axis/colour gradient follows
+    the actual values, not their string representation.
+    """
+    unique = list(dict.fromkeys(str(v) for v in values))
+    if is_categorical:
+        return sorted(unique)
+    numeric = []
+    for v in unique:
+        try:
+            numeric.append(float(v))
+        except (TypeError, ValueError):
+            numeric.append(float('nan'))
+    return sorted(
+        numeric,
+        key=lambda x: (np.isnan(x), float('inf') if np.isnan(x) else x),
+    )
+
+
+def create_interaction_plot(
+    stats: pd.DataFrame,
+    f1_name: str,
+    f2_name: str,
+    f1_is_categorical: bool,
+    f2_is_categorical: bool,
+    response_name: str,
+    response_units: Optional[str] = None,
+    f1_units: Optional[str] = None,
+    f2_units: Optional[str] = None,
+    error_mode: str = "none",
+    p_value: Optional[float] = None,
+    interaction_present: bool = True,
+) -> go.Figure:
+    """
+    Create an interaction plot (Stat-Ease / Design-Expert style).
+
+    One line is drawn for each level of ``f2`` spanning the levels of ``f1``
+    on the x-axis.  Parallel lines indicate little interaction while
+    crossing / non-parallel lines indicate an interaction.
+
+    Parameters
+    ----------
+    stats : pd.DataFrame
+        Output of :func:`interaction_stats`.
+    f1_name : str
+        Name of the x-axis factor.
+    f2_name : str
+        Name of the line-encoding (grouping) factor.
+    f1_is_categorical / f2_is_categorical : bool
+        Whether each factor is categorical (affects axis type, colouring and
+        level ordering).  Categorical levels are never coerced to numbers.
+    response_name : str
+        Display name of the response for the y-axis/tooltip.
+    response_units / f1_units / f2_units : str, optional
+        Units appended to axis labels.
+    error_mode : str
+        One of ``"none"`` (mean only), ``"sd"`` (mean +/- SD), ``"ci"``
+        (mean +/- 95% CI).  Error bars are omitted for single-replicate
+        combinations.
+    p_value : float, optional
+        Interaction term p-value from the fitted ANOVA, if available.
+    interaction_present : bool
+        Whether the ``f1:f2`` interaction term is present in the fitted model.
+        When ``False`` the significance subtitle reports "not in model".
+
+    Returns
+    -------
+    go.Figure
+        The interaction plot.
+
+    Examples
+    --------
+    >>> stats = interaction_stats('A', 'B', design, response)
+    >>> fig = create_interaction_plot(stats, 'A', 'B', True, False, 'Yield')
+    """
+# Ordered level lists, matching the order used for grouping/colouring.
+    f1_levels = _sorted_levels(stats[f1_name].values, f1_is_categorical)
+    f2_levels = _sorted_levels(stats[f2_name].values, f2_is_categorical)
+
+    # Map each numeric level to its string representation for group joins.
+    f1_str = {k: str(k) for k in f1_levels}
+    f2_str = {k: str(k) for k in f2_levels}
+    stats = stats.copy()
+    stats[f1_name] = stats[f1_name].map(lambda v: str(v))
+    stats[f2_name] = stats[f2_name].map(lambda v: str(v))
+
+    # Colour assignment per grouping level.
+    if f2_is_categorical:
+        line_colors = {
+            str(level): QUALITATIVE_COLORS[i % len(QUALITATIVE_COLORS)]
+            for i, level in enumerate(f2_levels)
+        }
+    else:
+        line_colors = {}
+        n = max(len(f2_levels), 1)
+        for i, level in enumerate(f2_levels):
+            color = SEQUENTIAL_COLORS[
+                int(round(i * (len(SEQUENTIAL_COLORS) - 1) / (n - 1)))
+            ] if n > 1 else SEQUENTIAL_COLORS[0]
+            line_colors[str(level)] = color
+
+    # X-axis: category axis for categorical factor, linear for numeric.
+    x_is_categorical = f1_is_categorical
+    x_values = [f1_str[l] for l in f1_levels]
+    if x_is_categorical:
+        x_values = [str(v) for v in x_values]
+    else:
+        x_values = [float(v) for v in x_values]
+
+    f1_label = _label_with_units(f1_name, f1_units)
+    f2_label = _label_with_units(f2_name, f2_units)
+    response_label = _label_with_units(response_name, response_units)
+
+    fig = go.Figure()
+
+    for level in f2_levels:
+        lvl_str = str(level)
+        subset = stats[stats[f2_name] == lvl_str]
+        # Align with the x-level order (fill missing combos with None).
+        y = []
+        sd_vals = []
+        n_vals = []
+        for x_lvl in f1_levels:
+            row = subset[subset[f1_name] == str(x_lvl)]
+            if row.empty:
+                y.append(None)
+                sd_vals.append(None)
+                n_vals.append(None)
+                continue
+            r = row.iloc[0]
+            y.append(None if pd.isna(r['mean']) else float(r['mean']))
+            sd_vals.append(
+                None if pd.isna(r['std']) else float(r['std'])
+            )
+            n_vals.append(int(r['n']))
+
+        error_y = None
+        if error_mode in ("sd", "ci") and len(f2_levels) > 0:
+            arrays = []
+            for idx, x_lvl in enumerate(f1_levels):
+                row = subset[subset[f1_name] == str(x_lvl)]
+                if row.empty or int(row.iloc[0]['n']) < 2:
+                    arrays.append(0.0)
+                elif error_mode == "sd":
+                    arrays.append(float(row.iloc[0]['std']))
+                else:
+                    arrays.append(float(
+                        row.iloc[0]['ci_upper'] - row.iloc[0]['mean']
+                    ))
+            error_y = dict(
+                type="data",
+                symmetric=True,
+                array=arrays,
+                thickness=1,
+                width=4,
+            )
+
+        # customdata carries (level, SD, n) so the tooltip can show them.
+        customdata = [
+            [lvl_str, sd_vals[i], n_vals[i]]
+            for i in range(len(f1_levels))
+        ]
+        fig.add_trace(
+            go.Scatter(
+                x=x_values,
+                y=y,
+                mode="lines+markers",
+                name=lvl_str,
+                line=dict(color=line_colors[lvl_str], width=2.5),
+                marker=dict(size=8, line=dict(width=1, color="white")),
+                error_y=error_y,
+                customdata=customdata,
+                hovertemplate=(
+                    f"{f1_name}: %{{x}}<br>"
+                    f"{f2_name}: %{{customdata[0]}}<br>"
+                    f"{response_name}: %{{y:.3f}}<br>"
+                    f"SD: %{{customdata[1]}}<br>"
+                    f"n: %{{customdata[2]}}<extra></extra>"
+                ),
+            )
+        )
+
+    # Interaction significance subtitle.
+    subtitle = None
+    if interaction_present and p_value is not None:
+        if p_value < 0.05:
+            verdict = "Significant interaction"
+        elif p_value < 0.10:
+            verdict = "Marginal interaction"
+        else:
+            verdict = "No significant interaction"
+        subtitle = f"{verdict} (interaction p-value = {p_value:g})"
+    elif not interaction_present:
+        subtitle = "Interaction not in model (N/A)"
+    else:
+        subtitle = None
+
+    layout_kwargs: Dict[str, object] = dict(
+        title=dict(
+            text=f"{response_label}  |  {f1_name} × {f2_name}",
+            font=dict(size=14),
+        ),
+        xaxis_title=f1_label,
+        yaxis_title=response_label,
+        xaxis_type="category" if x_is_categorical else "linear",
+        showlegend=True,
+        height=480,
+        legend=dict(title=dict(text=f2_label)),
+        hovermode="closest",
+    )
+    if subtitle:
+        layout_kwargs["title"]["subtitle"] = dict(text=subtitle)
+
+    fig.update_layout(**layout_kwargs)
+    fig.update_traces(connectgaps=False)
 
     return apply_plot_style(fig)

--- a/src/ui/utils/plotting.py
+++ b/src/ui/utils/plotting.py
@@ -1746,3 +1746,150 @@ def create_interaction_plot(
     fig.update_traces(connectgaps=False)
 
     return apply_plot_style(fig)
+
+
+def box_plot_stats(
+    factor_name: str,
+    design: pd.DataFrame,
+    response: np.ndarray,
+    is_categorical: bool,
+) -> pd.DataFrame:
+    """
+    Aggregate per-level response statistics for a box plot.
+
+    One row is returned per observed level of ``factor_name``.  Boxes are
+    drawn from the raw response values, so the Quartile/Min/Q1/Median/Q3/Max
+    summary is derived from the observed data rather than adjusted means.
+
+    Rows with a missing (NaN) response are dropped; factor levels that are
+    absent from the data produce no row at all (present levels only).
+
+    Parameters
+    ----------
+    factor_name : str
+        Name of the x-axis factor column.
+    design : pd.DataFrame
+        Design data (natural units) containing ``factor_name``.
+    response : np.ndarray
+        Response values aligned with ``design`` rows.
+    is_categorical : bool
+        Whether the factor is categorical.  Controls level ordering (see
+        :func:`_sorted_levels`); categorical levels are never coerced to
+        numbers.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``[factor_name, mean, std, n]`` ordered by level, plus
+        ``level`` holding the stable sorted level string used for plotting.
+    """
+    df = pd.DataFrame({
+        factor_name: np.asarray(design[factor_name].values),
+        'response': np.asarray(response, dtype=float),
+    })
+    # Missing responses are excluded.
+    df = df.dropna(subset=['response'])
+
+    ordered = _sorted_levels(df[factor_name].values, is_categorical)
+
+    rows = []
+    for level in ordered:
+        vals = df[df[factor_name].map(lambda v: str(v)) == str(level)]['response']
+        if vals.empty:
+            continue
+        vals = vals.astype(float).values
+        rows.append({
+            factor_name: level,
+            'level': str(level),
+            'n': int(len(vals)),
+            'mean': float(vals.mean()),
+            'std': float(vals.std(ddof=1)) if len(vals) > 1 else 0.0,
+        })
+
+    result = pd.DataFrame(rows, columns=[
+        factor_name, 'level', 'n', 'mean', 'std'
+    ])
+    return result
+
+
+def create_box_plot(
+    stats: pd.DataFrame,
+    factor_name: str,
+    factor_label: str,
+    response_name: str,
+    response_values_by_level: Dict[str, np.ndarray],
+    response_units: Optional[str] = None,
+    factor_units: Optional[str] = None,
+) -> go.Figure:
+    """
+    Create an IQR/Tukey box plot of the response for each factor level.
+
+    One ``go.Box`` trace is drawn per factor level and the raw response values
+    are used directly, so Plotly computes the whisker/outlier range (Q1-1.5
+    IQR, Q3+1.5 IQR) from the observed responses.  Boxes are drawn unfilled
+    (transparent body) with all-black outlines, whiskers, median line and
+    outlier markers, matching the standard industry convention for a
+    single-factor box plot.  The x-axis is a category axis keyed on the
+    factor level labels.
+
+    Parameters
+    ----------
+    stats : pd.DataFrame
+        Output of :func:`box_plot_stats`.
+    factor_name : str
+        Name of the factor column (used for tooltips).
+    factor_label : str
+        Display label for the factor (the natural name).
+    response_name : str
+        Display name of the response for the y-axis/tooltip.
+    response_values_by_level : Dict[str, np.ndarray]
+        Mapping from each level string to its raw (NaN-free) response values.
+        Keys must be the same level strings as ``stats['level']``.
+    response_units : str, optional
+        Units appended to the response axis label.
+    factor_units : str, optional
+        Units appended to the factor axis label.
+
+    Returns
+    -------
+    go.Figure
+        The box plot.
+    """
+    factor_axis_label = _label_with_units(factor_label, factor_units)
+    response_label = _label_with_units(response_name, response_units)
+
+    fig = go.Figure()
+
+    for level in stats['level']:
+        values = np.asarray(response_values_by_level[level], dtype=float)
+        n = stats.loc[stats['level'] == level, 'n'].iloc[0]
+        fig.add_trace(
+            go.Box(
+                y=values,
+                name=level,
+                boxpoints="outliers",
+                fillcolor="rgba(0,0,0,0)",
+                line=dict(color="#000000", width=1),
+                marker=dict(color="#000000", size=5),
+                hoveron="boxes",
+                hovertemplate=(
+                    f"{factor_name}: {level}<br>"
+                    f"{response_name}: %{{y:.3f}}<br>"
+                    f"n: {n}<extra></extra>"
+                ),
+            )
+        )
+
+    fig.update_layout(
+        title=dict(
+            text=f"{response_label}  |  {factor_label}",
+            font=dict(size=14),
+        ),
+        xaxis_title=factor_axis_label,
+        yaxis_title=response_label,
+        xaxis_type="category",
+        showlegend=False,
+        height=480,
+        hovermode="closest",
+    )
+    return apply_plot_style(fig)

--- a/src/ui/utils/plotting.py
+++ b/src/ui/utils/plotting.py
@@ -18,6 +18,8 @@ import plotly.graph_objects as go
 from scipy import stats
 from sklearn.linear_model import LinearRegression
 
+from src.core.analysis_base import attach_critical_limits
+
 # ==================== PLOT STYLING ====================
 
 PLOT_COLORS: Dict[str, str] = {
@@ -491,6 +493,280 @@ def create_logworth_plot(
         margin=dict(l=150, r=100),
     )
 
+    return apply_plot_style(fig)
+
+
+def _pformat(p: float) -> str:
+    """Format a p-value for hover text."""
+    if not np.isfinite(p):
+        return "n/a"
+    if p >= 0.0001:
+        return f"{p:.4f}"
+    return f"{p:.3g}"
+
+
+def _effect_plot_height(n_terms: int) -> int:
+    """Adaptive height proportional to the number of displayed terms."""
+    return max(280, n_terms * 26)
+
+
+def create_coefficient_significance_plot(
+    coefficient_significance_df: Optional[pd.DataFrame],
+    alpha: float = 0.05,
+    show_block: bool = True,
+) -> go.Figure:
+    """
+    Coefficient-level LogWorth Pareto (kept as-is from fitted-model tests).
+
+    Bars show ``-log10(coefficient p-value)`` for each fitted coefficient.
+    Intercept is excluded.  Block/design terms are styled distinctly and can
+    be filtered at display time only (no refit).  Significant rows are
+    colored; insignificant rows are desaturated so the α line reads clearly.
+
+    Parameters
+    ----------
+    coefficient_significance_df : Optional[pd.DataFrame]
+        Canonical coefficient_significance table.
+    alpha : float
+        Significance level; reference line at ``-log10(alpha)``.
+    show_block : bool
+        Whether to display block/design terms.
+
+    Returns
+    -------
+    go.Figure
+    """
+    if coefficient_significance_df is None or coefficient_significance_df.empty:
+        return _empty_effects_figure("Coefficient Significance (LogWorth)")
+    df = coefficient_significance_df.copy()
+    if not show_block:
+        df = df.loc[~df["is_block"].fillna(False)].copy()
+    if df.empty:
+        return _empty_effects_figure("Coefficient Significance (LogWorth)", hidden=True)
+
+    df["_is_block"] = df["is_block"].fillna(False).astype(bool)
+    df = df.sort_values("logworth", ascending=True)
+
+    colors = [
+        PLOT_COLORS["secondary"] if blk else PLOT_COLORS["primary"]
+        for blk in df["_is_block"]
+    ]
+    p_text = [_pformat(p) for p in df["p_value"]]
+    hover = [
+        (
+            f"<b>{name}</b><br>"
+            f"Parent ANOVA term: {parent or '—-'}"
+            f"{f' (DF={int(parent_df)})' if pd.notna(parent_df) else ''}<br>"
+            f"estimate={est:.4g} &nbsp;SE={se:.4g} &nbsp;t={t:.3f}<br>"
+            f"coefficient p={_pformat(p)} &nbsp;LogWorth={lw:.2f}<br>"
+            f"{'<b>Block/design term</b><br>' if blk else ''}"
+            f"Source: {src}"
+        )
+        for name, parent, parent_df, est, se, t, p, lw, blk, src in zip(
+            df["coefficient_name"],
+            df["parent_anova_term"],
+            df["parent_anova_df"],
+            df["coefficient_estimate"],
+            df["standard_error"],
+            df["t_value"],
+            df["p_value"],
+            df["logworth"],
+            df["_is_block"],
+            df["source"],
+        )
+    ]
+
+    fig = go.Figure()
+
+    colormap = dict(zip(df.index, colors))
+    cmap_p = dict(zip(df.index, p_text))
+    cmap_h = dict(zip(df.index, hover))
+
+    def _add_bars(sub, pattern):
+        if sub.empty:
+            return
+        fig.add_trace(
+            go.Bar(
+                x=sub["logworth"],
+                y=sub["coefficient_name"],
+                orientation="h",
+                marker=dict(
+                    color=[colormap[i] for i in sub.index],
+                    line=dict(color="#000000", width=0.5),
+                    pattern=dict(shape=pattern) if pattern else None,
+                ),
+                text=[cmap_p[i] for i in sub.index],
+                textposition="outside",
+                textfont=dict(size=10),
+                customdata=[cmap_h[i] for i in sub.index],
+                hovertemplate="%{customdata}<extra></extra>",
+            )
+        )
+
+    _add_bars(df.loc[~df["_is_block"]], pattern="")
+    _add_bars(df.loc[df["_is_block"]], pattern="/")
+
+    threshold = -np.log10(alpha)
+    fig.add_vline(
+        x=threshold,
+        line=dict(color=PLOT_COLORS["danger"], dash="dash", width=2),
+        annotation=dict(
+            text=f"α={alpha}", textangle=0, yref="paper", y=0.95, font=dict(size=10)
+        ),
+    )
+    fig.update_layout(
+        title=dict(
+            text="Coefficient Significance (LogWorth)",
+            font=dict(size=15),
+        ),
+        xaxis_title="LogWorth (-log₁₀ of fitted-model coefficient p)",
+        yaxis_title="",
+        height=_effect_plot_height(len(df)),
+        showlegend=False,
+        margin=dict(l=190, r=110),
+    )
+    fig.update_yaxes(automargin=True, tickfont=dict(size=11))
+    return apply_plot_style(fig)
+
+
+def create_standardized_effects_plot(
+    anova_effect_summary_df: Optional[pd.DataFrame],
+    alpha: float = 0.05,
+    show_block: bool = True,
+) -> go.Figure:
+    """
+    DOE Pareto of Standardized Effects, sourced from the ANOVA table.
+
+    One-Df terms use ``|t| = sqrt(F)`` (signed by the coefficient estimate).
+    Multi-Df terms (e.g. categorical main effects) use an omnibus
+    ``sqrt(F)`` score and are shown in a neutral color; they are not
+    presented as one-Df effects.  Critical limits (t and Bonferroni) are
+    drawn only when every displayed term shares a single residual DF.
+    """
+    if anova_effect_summary_df is None or anova_effect_summary_df.empty:
+        return _empty_effects_figure("DOE Pareto of Standardized Effects")
+    df = anova_effect_summary_df.copy()
+    if not show_block:
+        df = df.loc[~df["is_block"].fillna(False)].copy()
+    if df.empty:
+        return _empty_effects_figure(
+            "DOE Pareto of Standardized Effects", hidden=True
+        )
+
+    df["_is_block"] = df["is_block"].fillna(False).astype(bool)
+    df["_abs"] = df["standardized_statistic"].astype(float).abs()
+    df = df.loc[df["_abs"].notna()].sort_values("_abs", ascending=True)
+
+    colors = []
+    for _, row in df.iterrows():
+        if row["_is_block"] or row["standardized_statistic_type"] == "omnibus sqrt(F)":
+            colors.append(PLOT_COLORS["neutral"])
+        elif float(row["standardized_statistic"]) < 0:
+            colors.append(PLOT_COLORS["danger"])
+        else:
+            colors.append(PLOT_COLORS["primary"])
+
+    labels = [
+        (
+            f"<b>{term}</b>{' <i>(block)</i>' if blk else ''}<br>"
+            f"{stat_type} = {stat:.3f}<br>"
+            f"DF={int(dof) if pd.notna(dof) else '?'} &nbsp;"
+            f"F={fstat:.3f} &nbsp;p={_pformat(p)}<br>"
+            f"residual DF={int(rd) if pd.notna(rd) else '?'}<br>"
+            f"{'t-critical=%.3f  Bonferroni=%.3f' % (tc, bc) if pd.notna(tc) else ''}<br>"
+            f"<i>{'Multi-Df term: shown as omnibus sqrt(F), not a one-Df t' if dof is not None and dof > 1 else ''}</i>"
+            f"effect estimate={est:.4g} &nbsp;sign={'+' if sgn > 0 else ('-' if sgn < 0 else '0')}<br>"
+            f"Source: {src}"
+        )
+        for term, blk, stat_type, stat, dof, fstat, p, rd, tc, bc, est, sgn, src in zip(
+            df["term"],
+            df["_is_block"],
+            df["standardized_statistic_type"],
+            df["standardized_statistic"],
+            df["df"],
+            df["F"],
+            df["p_value"],
+            df["residual_df"],
+            df["t_critical"],
+            df["bonferroni_limit"],
+            df["effect_estimate"],
+            df["effect_sign"],
+            df["source"],
+        )
+    ]
+    # Short single-line axis labels; the verbose block lives in hover only.
+    ylabels = [
+        f"{term}{' (block)' if blk else ''}"
+        for term, blk in zip(df["term"], df["_is_block"])
+    ]
+
+    fig = go.Figure()
+
+    colormap = dict(zip(df.index, colors))
+    cmap_l = dict(zip(df.index, labels))
+    cmap_y = dict(zip(df.index, ylabels))
+
+    def _add_std_bars(sub, pattern):
+        if sub.empty:
+            return
+        fig.add_trace(
+            go.Bar(
+                x=sub["_abs"],
+                y=[cmap_y[i] for i in sub.index],
+                orientation="h",
+                marker=dict(
+                    color=[colormap[i] for i in sub.index],
+                    line=dict(color="#000000", width=0.5),
+                    pattern=dict(shape=pattern) if pattern else None,
+                ),
+                text=[f"{s:.2f}".replace("+", "") for s in sub["standardized_statistic"]],
+                textposition="outside",
+                textfont=dict(size=10),
+                customdata=[cmap_l[i] for i in sub.index],
+                hovertemplate="%{customdata}<extra></extra>",
+            )
+        )
+
+    _add_std_bars(df.loc[~df["_is_block"]], pattern="")
+    _add_std_bars(df.loc[df["_is_block"]], pattern="/")
+
+    # Critical limits: only when every displayed term shares one residual DF.
+    residuals = df["residual_df"].dropna().unique()
+    if len(residuals) == 1 and np.isfinite(residuals[0]):
+        tc, bc = df["t_critical"].iloc[0], df["bonferroni_limit"].iloc[0]
+        if np.isfinite(tc):
+            fig.add_vline(x=tc, line=dict(color=PLOT_COLORS["danger"], dash="dash"))
+        if np.isfinite(bc):
+            fig.add_vline(x=bc, line=dict(color=PLOT_COLORS["sigma2"], dash="dot"))
+    else:
+        fig.add_annotation(
+            text="No universal t/Bonferroni limit: residual DF vary across strata",
+            xref="paper", yref="paper", x=1.0, y=-0.12, showarrow=False,
+            font=dict(size=9, color=PLOT_COLORS["neutral"]),
+            xanchor="right",
+        )
+
+    fig.update_layout(
+        title=dict(text="DOE Pareto of Standardized Effects", font=dict(size=15)),
+        xaxis_title="Standardized ANOVA Statistic (|t| = sqrt(F) for one-Df terms)",
+        yaxis_title="",
+        height=_effect_plot_height(len(df)),
+        showlegend=False,
+        margin=dict(l=190, r=130),
+    )
+    fig.update_yaxes(automargin=True, tickfont=dict(size=11))
+    return apply_plot_style(fig)
+
+
+def _empty_effects_figure(title: str, hidden: bool = False) -> go.Figure:
+    fig = go.Figure()
+    fig.add_annotation(
+        text="No effects available"
+        if not hidden
+        else "No effects to show (block/design terms hidden)",
+        xref="paper", yref="paper", x=0.5, y=0.5, showarrow=False,
+    )
+    fig.update_layout(title=dict(text=title, font=dict(size=15)), height=280)
     return apply_plot_style(fig)
 
 
@@ -1254,25 +1530,25 @@ def interaction_stats(
 
 
 def _sorted_levels(values, is_categorical: bool):
-    """Return the ordered set of level values for a factor column.
+    """Return the ordered set of level strings for a factor column.
 
     Categorical levels are sorted lexicographically to give a stable order;
     numeric levels are sorted numerically so the axis/colour gradient follows
-    the actual values, not their string representation.
+    the actual values, not their string representation.  Returns the original
+    string representations (not floats) so downstream ``str(level)`` joins
+    match the stringified stats DataFrame exactly.
     """
     unique = list(dict.fromkeys(str(v) for v in values))
     if is_categorical:
         return sorted(unique)
-    numeric = []
-    for v in unique:
+    pairs = []
+    for s in unique:
         try:
-            numeric.append(float(v))
+            pairs.append((float(s), s))
         except (TypeError, ValueError):
-            numeric.append(float('nan'))
-    return sorted(
-        numeric,
-        key=lambda x: (np.isnan(x), float('inf') if np.isnan(x) else x),
-    )
+            pairs.append((float('inf'), s))
+    pairs.sort(key=lambda p: (np.isnan(p[0]), p[0]))
+    return [p[1] for p in pairs]
 
 
 def create_interaction_plot(
@@ -1331,13 +1607,10 @@ def create_interaction_plot(
     >>> stats = interaction_stats('A', 'B', design, response)
     >>> fig = create_interaction_plot(stats, 'A', 'B', True, False, 'Yield')
     """
-# Ordered level lists, matching the order used for grouping/colouring.
+    # Ordered level lists, matching the order used for grouping/colouring.
     f1_levels = _sorted_levels(stats[f1_name].values, f1_is_categorical)
     f2_levels = _sorted_levels(stats[f2_name].values, f2_is_categorical)
 
-    # Map each numeric level to its string representation for group joins.
-    f1_str = {k: str(k) for k in f1_levels}
-    f2_str = {k: str(k) for k in f2_levels}
     stats = stats.copy()
     stats[f1_name] = stats[f1_name].map(lambda v: str(v))
     stats[f2_name] = stats[f2_name].map(lambda v: str(v))
@@ -1359,7 +1632,7 @@ def create_interaction_plot(
 
     # X-axis: category axis for categorical factor, linear for numeric.
     x_is_categorical = f1_is_categorical
-    x_values = [f1_str[l] for l in f1_levels]
+    x_values = list(f1_levels)
     if x_is_categorical:
         x_values = [str(v) for v in x_values]
     else:

--- a/src/ui/utils/response_definitions.py
+++ b/src/ui/utils/response_definitions.py
@@ -1,0 +1,120 @@
+"""
+Response name definition helpers (pure, Streamlit-free).
+
+Response names must be safe to embed in Patsy / statsmodels formula strings,
+so free-form names are sanitized on save (mirroring the factors grid).  These
+helpers are intentionally free of any Streamlit dependency so they can be
+unit-tested directly.
+"""
+
+import re
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from src.core.factor_naming import sanitize_factor_name, get_sanitization_report
+
+
+def validate_response_name(name: str, existing_responses: list) -> bool:
+    """
+    Validate a sanitized response name.
+
+    Rules:
+    - Must be alphanumeric + underscore
+    - Must not be duplicate (case-insensitive)
+    - Must not be reserved word
+
+    Parameters
+    ----------
+    name : str
+        Response name (already sanitized to a valid identifier).
+    existing_responses : list
+        Iterable of ``{'name': ...}`` dicts (or objects with ``.name``) for the
+        names already claimed in this batch.
+
+    Returns
+    -------
+    bool
+        ``True`` if the name may be used.
+    """
+    # Check format
+    if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', name):
+        return False
+
+    # Check for duplicates (case-insensitive)
+    existing_names = []
+    for r in existing_responses:
+        n = r['name'] if isinstance(r, dict) else getattr(r, 'name', '')
+        existing_names.append(n.lower())
+    if name.lower() in existing_names:
+        return False
+
+    # Check for reserved words
+    reserved = {'I', 'C', 'Q', 'T'}  # patsy/pandas reserved
+    if name in reserved:
+        return False
+
+    return True
+
+
+def response_rows_to_definitions(df: pd.DataFrame):
+    """
+    Convert an editable responses table into sanitized response definitions.
+
+    Accepts free-form response names (mirroring the factors grid): spaces,
+    parens, and other formula-unsafe characters are auto-cleaned so the stored
+    name is a valid Patsy-safe identifier. Returns the definitions list plus
+    validation errors and sanitization warnings.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Editor rows with 'Name' and 'Units' columns.
+
+    Returns
+    -------
+    definitions : List[Dict[str, Optional[str]]]
+        Sanitized ``{'name': ..., 'units': ... or None}`` entries.
+    errors : List[str]
+        Human-readable validation errors (empty names, duplicates, reserved).
+    sanitization_warnings : List[Dict]
+        Per-row records of name sanitization for display.
+    """
+    definitions = []
+    errors = []
+    sanitization_warnings = []
+    used_names = set()
+
+    for idx, row in df.iterrows():
+        raw = str(row['Name']).strip() if not pd.isna(row['Name']) else ''
+        if not raw or raw.lower() in ('nan', 'none', ''):
+            continue  # skip blank rows
+
+        clean, was_modified = sanitize_factor_name(raw)
+
+        if was_modified:
+            report = get_sanitization_report(raw)
+            sanitization_warnings.append({
+                'row': idx + 1,
+                'original': raw,
+                'sanitized': clean,
+                'changes': report['changes'],
+            })
+
+        if not validate_response_name(clean, [{'name': n} for n in used_names]):
+            errors.append(
+                f"Row {idx + 1}: response name '{raw}' "
+                f"(cleaned: '{clean}') is invalid or already exists"
+            )
+            continue
+
+        used_names.add(clean)
+
+        units_raw = row.get('Units')
+        units = str(units_raw).strip() if not pd.isna(units_raw) else ''
+        definitions.append({
+            'name': clean,
+            'units': units if units else None,
+        })
+
+    return definitions, errors, sanitization_warnings

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -526,7 +526,7 @@ class TestDegreesOfFreedom:
         assert results.r_squared == 1.0
         assert 'A' in results.effect_estimates.index
     
-     def test_oversaturated_model_warns(self):
+    def test_oversaturated_model_warns(self):
         """Test that oversaturated model (df<0) warns."""
         factors = [
             Factor("A", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[-1, 1]),
@@ -869,6 +869,48 @@ class TestValidationData:
     def test_basic_factorial_validation(self):
         """Basic validation test - will expand later."""
         pass
+
+
+class TestBlocking:
+    """Test that blocking is included in the ANOVA analysis as a fixed effect."""
+
+    def _blocked_design(self):
+        """A 2^2 factorial in 2 blocks with replicates (natural units)."""
+        factors = [
+            Factor("A", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[-1, 1]),
+            Factor("B", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[-1, 1])
+        ]
+        design = full_factorial(factors, n_replicates=2, n_blocks=2, randomize=False)
+        # Block effect: block 1 adds -5, block 2 adds +5
+        block_effect = np.where(design['Block'] == 1, -5.0, 5.0)
+        response = 10 + 2 * design['A'] + 3 * design['B'] + block_effect
+        return design, response, factors
+
+    def test_fixed_effect_block_fits(self):
+        """Block included as a fixed effect by default."""
+        design, response, factors = self._blocked_design()
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(['A', 'B'])
+
+        assert results is not None
+        # Block term should appear in the ANOVA table
+        assert 'Block' in results.anova_table.index
+
+    def test_design_structure_detects_blocking(self):
+        """Detection sees a Block column in a blocked design."""
+        design, response, factors = self._blocked_design()
+        analysis = ANOVAAnalysis(design, response, factors)
+        assert analysis.design_structure['has_blocking'] is True
+
+    def test_replicated_blocked_design_fits(self):
+        """A design with both replicates and blocks fits the fixed-effect model."""
+        design, response, factors = self._blocked_design()
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(['A', 'B'])
+
+        assert results is not None
+        assert 'Block' in results.anova_table.index
+        assert results.r_squared > 0.99
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -913,5 +913,115 @@ class TestBlocking:
         assert results.r_squared > 0.99
 
 
+class TestCategoricalNumericLabels:
+    """Categorical factors with numeric-looking levels must be fit as
+    categorical (k-1 dummy columns), not silently as continuous."""
+
+    def test_parse_model_term_strips_c_wrapper(self):
+        """parse_model_term tolerates patsy C(...) wrappers."""
+        main_factors, op1 = parse_model_term('C(Egg_lot)')
+        assert main_factors == ['Egg_lot']
+        assert op1 == ''
+
+        int_factors, op2 = parse_model_term('C(Egg_lot)*Egg_percent')
+        assert int_factors == ['Egg_lot', 'Egg_percent']
+        assert op2 == '*'
+
+    def test_full_factorial_categorical_df(self):
+        """4-level categorical x 2-level numeric with replicates: lot DF=3,
+        percent DF=1, interaction DF=3 (was DF=1 when coerced to numeric)."""
+        lot_levels = ['41007587', '41005191', '41007741', '41007302']
+        factors = [
+            Factor('Egg_lot', FactorType.CATEGORICAL, ChangeabilityLevel.EASY,
+                   levels=lot_levels, _validate_on_init=False),
+            Factor('Egg_percent', FactorType.DISCRETE_NUMERIC,
+                   ChangeabilityLevel.EASY, levels=[10, 20]),
+        ]
+
+        design = full_factorial(factors, n_replicates=2, randomize=False)
+        # Egg_lot column must remain a string column in the design
+        assert pd.api.types.is_string_dtype(design['Egg_lot'])
+        assert design['Egg_lot'].nunique() == 4
+
+        # Deterministic response: strong lot effect, mild percent + noise
+        rng = np.random.default_rng(42)
+        lot_means = {lot: m for lot, m in zip(lot_levels, [100, 102, 98, 105])}
+        response = (
+            design['Egg_lot'].map(lot_means).astype(float)
+            + 1.5 * design['Egg_percent']
+            + rng.normal(0, 0.05, len(design))
+        )
+
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(['Egg_lot', 'Egg_percent', 'Egg_lot*Egg_percent'])
+
+        df = results.anova_table['df']
+        assert results.anova_table.index.get_loc('Egg_lot') is not None
+        assert int(df.loc['Egg_lot']) == 3
+        assert int(df.loc['Egg_percent']) == 1
+        assert int(df.loc['Egg_lot:Egg_percent']) == 3
+
+        # No C(...) wrappers leak into reported labels
+        assert not any('C(' in str(i) for i in results.anova_table.index)
+        assert not any('C(' in str(i) for i in results.effect_estimates.index)
+
+        # effect_estimates use plain [T.level] dummy keys (predict compat)
+        main_dummy_keys = [
+            i for i in results.effect_estimates.index
+            if str(i).startswith('Egg_lot[') and ':' not in str(i)
+        ]
+        assert len(main_dummy_keys) == 3
+        interaction_keys = [
+            i for i in results.effect_estimates.index
+            if str(i).startswith('Egg_lot[') and ':' in str(i)
+        ]
+        assert len(interaction_keys) == 3
+
+    def test_categorical_df_matches_dummy_regression(self):
+        """Wrapped formula produces the same DF as coding the dummies by hand."""
+        lot_levels = ['41007587', '41005191', '41007741', '41007302']
+        factors = [
+            Factor('Egg_lot', FactorType.CATEGORICAL, ChangeabilityLevel.EASY,
+                   levels=lot_levels, _validate_on_init=False),
+            Factor('Egg_percent', FactorType.DISCRETE_NUMERIC,
+                   ChangeabilityLevel.EASY, levels=[10, 20]),
+        ]
+        design = full_factorial(factors, n_replicates=2, randomize=False)
+
+        rng = np.random.default_rng(7)
+        lot_means = {lot: m for lot, m in zip(lot_levels, [50, 52, 48, 55])}
+        response = (
+            design['Egg_lot'].map(lot_means).astype(float)
+            + 0.5 * design['Egg_percent']
+            + rng.normal(0, 0.1, len(design))
+        )
+
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(['Egg_lot', 'Egg_percent', 'Egg_lot*Egg_percent'])
+        df = results.anova_table['df']
+
+        # Reference: hand-built design matrix using 3 lot dummies + numeric,
+        # plus the 3 per-level interaction columns (dummy * percent)
+        ref = pd.get_dummies(design['Egg_lot'], prefix='Egg_lot', prefix_sep='')
+        ref = ref.iloc[:, 1:]  # drop the reference level (fits with intercept)
+        X = pd.concat([design[['Egg_percent']], ref], axis=1)
+        for col in ref.columns:
+            X[f'{col}:Egg_percent'] = ref[col] * design['Egg_percent']
+        from statsmodels.api import OLS
+        ref_fit = OLS(response, sm_add_constant(X)).fit()
+        ref_rsq = ref_fit.rsquared
+
+        assert df.loc['Egg_lot'] == 3
+        assert df.loc['Egg_percent'] == 1
+        assert df.loc['Egg_lot:Egg_percent'] == 3
+        assert abs(results.r_squared - ref_rsq) < 1e-9
+
+
+def sm_add_constant(frame):
+    """Add an intercept column to an arbitrary DataFrame."""
+    import statsmodels.api as sm
+    return sm.add_constant(frame)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_box_plot.py
+++ b/tests/test_box_plot.py
@@ -1,0 +1,199 @@
+"""
+Tests for the box plot component.
+
+The box-plot core lives in ``src.ui.utils.plotting`` as pure, testable
+functions (:func:`box_plot_stats` and :func:`create_box_plot`) so these tests
+exercise the figure-building logic directly without a Streamlit harness,
+matching the convention used by the interaction-plot helpers.
+
+Edge cases covered:
+- one box per observed factor level (present levels only)
+- categorical factor labels containing numbers (never coerced to numeric)
+- replicated vs non-replicated designs
+- missing response values are dropped
+- numeric factor level sorting
+- Tukey whisker/outlier behaviour delegated to Plotly
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.ui.utils.plotting import (
+    box_plot_stats,
+    create_box_plot,
+)
+from src.core.factors import Factor, FactorType, ChangeabilityLevel
+from src.core.full_factorial import full_factorial
+
+
+class BaseBoxFixture:
+    """Shared factory helpers for the box-plot tests."""
+
+    LOT_LEVELS = ["41007587", "41005191", "41007741", "41007302"]
+
+    @staticmethod
+    def lot_factors():
+        """Categorical Egg_lot (numeric-looking labels) + numeric Egg_percent."""
+        return [
+            Factor(
+                "Egg_lot",
+                FactorType.CATEGORICAL,
+                ChangeabilityLevel.EASY,
+                levels=BaseBoxFixture.LOT_LEVELS,
+                _validate_on_init=False,
+            ),
+            Factor(
+                "Egg_percent",
+                FactorType.DISCRETE_NUMERIC,
+                ChangeabilityLevel.EASY,
+                levels=[1.2, 1.8],
+            ),
+        ]
+
+    @staticmethod
+    def build_lot_design(n_replicates=2, seed=42):
+        factors = BaseBoxFixture.lot_factors()
+        design = full_factorial(
+            factors, n_replicates=n_replicates, randomize=False
+        )
+        rng = np.random.default_rng(seed)
+        lot_means = {
+            lot: m
+            for lot, m in zip(
+                BaseBoxFixture.LOT_LEVELS, [100, 102, 98, 105]
+            )
+        }
+        response = (
+            design["Egg_lot"].map(lot_means).astype(float)
+            + 1.5 * design["Egg_percent"]
+            + rng.normal(0, 0.05, len(design))
+        )
+        return design, np.asarray(response, dtype=float), factors
+
+
+class TestBoxPlotStats(BaseBoxFixture):
+    """Aggregation logic."""
+
+    def test_one_row_per_level(self):
+        design, response, factors = self.build_lot_design(n_replicates=2)
+        stats = box_plot_stats(
+            "Egg_lot", design, response, is_categorical=True
+        )
+        # 4 lots with 2 replicates across 2 percents -> one row per lot.
+        assert list(stats["level"]) == sorted(self.LOT_LEVELS)
+        assert all(stats["n"] == 4)
+
+    def test_numeric_levels_stay_strings(self):
+        design, response, factors = self.build_lot_design()
+        stats = box_plot_stats(
+            "Egg_lot", design, response, is_categorical=True
+        )
+        assert all(isinstance(v, str) for v in stats["level"])
+
+    def test_numeric_factor_levels_sorted_numerically(self):
+        factors = [
+            Factor("Temp", FactorType.DISCRETE_NUMERIC,
+                   ChangeabilityLevel.EASY, levels=[70, 80]),
+        ]
+        design = full_factorial(factors, n_replicates=2, randomize=False)
+        response = np.array([10.0, 12.0, 16.0, 18.0], dtype=float)
+        stats = box_plot_stats("Temp", design, response, is_categorical=False)
+        # Levels sorted numerically, not lexically.
+        assert list(stats["level"]) == ["70", "80"]
+        assert all(isinstance(v, str) for v in stats["level"])
+
+    def test_non_replicated_collapses_std(self):
+        # Deterministic response -> identical values within a level.
+        factors = [
+            Factor("A", FactorType.CATEGORICAL, ChangeabilityLevel.EASY,
+                   levels=["a", "b"]),
+        ]
+        design = full_factorial(factors, n_replicates=3, randomize=False)
+        # Row order is a,b,a,b,a,b; assign each level a single constant value.
+        response = np.array(
+            [10.0, 20.0, 10.0, 20.0, 10.0, 20.0]
+        )
+        stats = box_plot_stats("A", design, response, is_categorical=True)
+        assert list(stats["level"]) == ["a", "b"]
+        assert all(stats["std"] == 0.0)
+        assert list(stats["n"]) == [3, 3]
+
+    def test_missing_response_drops_row_value(self):
+        design, response, factors = self.build_lot_design(n_replicates=2)
+        # Null both replicates of the first run's lot.
+        response = response.copy()
+        first_lot_runs = design.index[design["Egg_lot"] == self.LOT_LEVELS[0]]
+        response[first_lot_runs] = np.nan
+        stats = box_plot_stats(
+            "Egg_lot", design, response, is_categorical=True
+        )
+        assert self.LOT_LEVELS[0] not in list(stats["level"])
+        assert len(stats) == 3
+        # No NaN anywhere.
+        assert not pd.isna(stats["mean"]).any()
+
+
+class TestCreateBoxPlot(BaseBoxFixture):
+    """Figure-building behaviour."""
+
+    def _fig(self, **kwargs):
+        design, response, factors = self.build_lot_design()
+        stats = box_plot_stats(
+            "Egg_lot", design, response, is_categorical=True
+        )
+        values_map = {
+            level: design.loc[design["Egg_lot"] == level, :].index.map(
+                lambda i: response[i]
+            ).values.astype(float)
+            for level in stats["level"]
+        }
+        default = {
+            "stats": stats,
+            "factor_name": "Egg_lot",
+            "factor_label": "Egg_lot",
+            "response_name": "Day_7_Max_Force",
+            "response_values_by_level": values_map,
+        }
+        default.update(kwargs)
+        return create_box_plot(**default)
+
+    def test_one_box_per_level(self):
+        fig = self._fig()
+        assert len(fig.data) == 4  # four lot levels
+        assert fig.layout.xaxis.type == "category"
+        assert all(isinstance(t.type, str) and "box" in t.type for t in fig.data)
+
+    def test_boxes_unfilled_all_black(self):
+        fig = self._fig()
+        for t in fig.data:
+            assert t.fillcolor in (None, "rgba(0,0,0,0)")
+            assert t.line.color == "#000000"
+            assert t.marker.color == "#000000"
+
+    def test_y_axis_label_includes_units(self):
+        fig = self._fig(response_units="kg")
+        assert fig.layout.yaxis.title.text == "Day_7_Max_Force (kg)"
+
+    def test_tooltip_includes_response_and_n(self):
+        fig = self._fig()
+        tmpl = fig.data[0].hovertemplate
+        assert "Day_7_Max_Force:" in tmpl and "n:" in tmpl
+        assert "Egg_lot:" in tmpl
+
+    def test_2_level_design(self):
+        factors = [
+            Factor("A", FactorType.CATEGORICAL, ChangeabilityLevel.EASY,
+                   levels=["a", "b"]),
+        ]
+        design = full_factorial(factors, randomize=False)
+        response = np.array([10.0, 12.0])
+        stats = box_plot_stats("A", design, response, is_categorical=True)
+        values_map = {
+            level: np.array([response[i] for i in design.index
+                             if str(design.loc[i, "A"]) == level])
+            for level in stats["level"]
+        }
+        fig = create_box_plot(stats, "A", "A", "Resp", values_map)
+        assert len(fig.data) == 2
+        assert fig.layout.xaxis.type == "category"

--- a/tests/test_csv_import_export.py
+++ b/tests/test_csv_import_export.py
@@ -15,6 +15,10 @@ from src.ui.utils.csv_parser import (
     CSVParseError,
 )
 from src.core.factors import Factor, FactorType, ChangeabilityLevel
+from src.ui.utils.response_definitions import (
+    validate_response_name,
+    response_rows_to_definitions,
+)
 
 
 @pytest.fixture
@@ -458,3 +462,69 @@ class TestEdgeCases:
         
         assert len(result.design_data) == 100
         assert result.is_valid
+
+
+class TestResponseDefinitions:
+    """Response-name sanitization and deduplication (mirrors the factors grid)."""
+
+    def _df(self, rows):
+        return pd.DataFrame(rows, columns=['Name', 'Units'])
+
+    def test_free_form_name_is_sanitized(self):
+        defs, errors, warnings = response_rows_to_definitions(
+            self._df([['Day 0 Max Force (g)', 'g']])
+        )
+        assert errors == []
+        assert len(warnings) == 1
+        assert warnings[0]['sanitized'] == 'Day_0_Max_Force_g'
+        assert defs == [{'name': 'Day_0_Max_Force_g', 'units': 'g'}]
+
+    def test_valid_name_passthrough_without_warning(self):
+        defs, errors, warnings = response_rows_to_definitions(
+            self._df([['Yield', '%'], ['Purity', 'mg/mL']])
+        )
+        assert errors == []
+        assert warnings == []
+        assert defs[0] == {'name': 'Yield', 'units': '%'}
+        assert defs[1] == {'name': 'Purity', 'units': 'mg/mL'}
+
+    def test_empty_units_become_none(self):
+        defs, errors, _ = response_rows_to_definitions(
+            self._df([['Yield', '']])
+        )
+        assert errors == []
+        assert defs == [{'name': 'Yield', 'units': None}]
+
+    def test_blank_rows_are_skipped(self):
+        defs, errors, _ = response_rows_to_definitions(
+            self._df([['', ''], ['Yield', '%'], [None, None]])
+        )
+        assert errors == []
+        assert defs == [{'name': 'Yield', 'units': '%'}]
+
+    def test_sanitized_duplicate_is_rejected(self):
+        # 'Max-Force' and 'Max Force' both sanitize to 'Max_Force'.
+        defs, errors, warnings = response_rows_to_definitions(
+            self._df([['Max-Force', ''], ['Max Force', '']])
+        )
+        assert defs == [{'name': 'Max_Force', 'units': None}]
+        assert len(errors) == 1
+        assert 'already exists' in errors[0]
+        assert len(warnings) == 2
+
+    def test_reserved_name_is_auto_cleaned(self):
+        # 'I' is Patsy-reserved and gets prefixed to 'f_I' during sanitization,
+        # so it is accepted with a warning rather than rejected.
+        defs, errors, warnings = response_rows_to_definitions(
+            self._df([['I', '']])
+        )
+        assert errors == []
+        assert defs == [{'name': 'f_I', 'units': None}]
+        assert len(warnings) == 1
+
+    def test_validate_response_name_checks_rules(self):
+        assert validate_response_name('Yield', [])
+        assert not validate_response_name('Yield', [{'name': 'yield'}])  # case-insensitive
+        assert not validate_response_name('I', [])
+        assert not validate_response_name('bad name', [])
+        assert not validate_response_name('2nd', [])

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -13,6 +13,7 @@ from src.ui.utils.csv_parser import (
     extract_factor_definitions,
     extract_response_definitions,
     extract_design_data,
+    extract_model_terms,
     validate_csv_structure,
     generate_doe_csv,
     CSVParseError,
@@ -215,6 +216,45 @@ class TestResponseExtraction:
         assert len(responses) == 1
         assert responses[0]["name"] == "Yield"
         assert responses[0]["units"] is None
+
+
+class TestModelTermsExtraction:
+    """Tests for extracting model terms from the CSV header."""
+
+    def test_extract_design_model_terms(self) -> None:
+        """Test parsing pipe-delimited model terms row."""
+        lines = [
+            "# MODEL TERMS",
+            "# Response,Terms",
+            "# __design__,1|Load|Flow|Speed|Mud",
+        ]
+        model_terms = extract_model_terms(lines)
+
+        assert model_terms == {
+            "__design__": ["1", "Load", "Flow", "Speed", "Mud"]
+        }
+
+    def test_strips_excel_column_padding_trailing_commas(self) -> None:
+        """Excel re-saves pad metadata lines with trailing commas. They must not
+        leak into the last pipe-delimited term (regression for the
+        'Mud,,,,,' factor-not-found crash)."""
+        lines = [
+            "# MODEL TERMS,,,,,,",
+            "# Response,Terms,,,,,",
+            "# __design__,1|Load|Flow|Speed|Mud,,,,,",
+        ]
+        model_terms = extract_model_terms(lines)
+
+        assert model_terms["__design__"] == ["1", "Load", "Flow", "Speed", "Mud"]
+
+    def test_missing_model_terms_section_returns_empty(self) -> None:
+        """Test that absent MODEL TERMS section yields an empty dict."""
+        lines = [
+            "# DOE-TOOLKIT DESIGN",
+            "# DESIGN DATA",
+            "1,2,3",
+        ]
+        assert extract_model_terms(lines) == {}
 
 
 class TestDesignDataExtraction:

--- a/tests/test_effect_charts.py
+++ b/tests/test_effect_charts.py
@@ -1,0 +1,355 @@
+"""Tests for the two complementary effect charts and their canonical tables.
+
+- ``ANOVAResults.coefficient_significance``: coefficient-level tests taken
+  from the fitted model (``fitted_model.pvalues``), preserved unchanged.
+- ``ANOVAResults.anova_effect_summary``: term-level tests sourced from the
+  displayed ANOVA table (``PR(>F)`` / ``P``), with standardized statistics
+  ``|t| = sqrt(F)`` (one-Df) or ``omnibus sqrt(F)`` (multi-Df).
+
+See the repository docs for the verified Yield example: Temperature has an
+ANOVA F = 88.5088 (p = 1.08e-9) while its fitted-model coefficient test has a
+very different p-value.  The two views intentionally answer different
+questions and must not be merged.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from pathlib import Path
+
+from src.core.analysis import ANOVAAnalysis
+from src.core.analysis_base import (
+    BONFERRONI_EXCLUDE_BLOCK,
+    attach_critical_limits,
+    coefficient_logworth,
+)
+from src.core.factors import Factor, FactorType, ChangeabilityLevel
+from src.ui.utils.plotting import (
+    create_coefficient_significance_plot,
+    create_standardized_effects_plot,
+)
+
+DATA_DIR = Path(__file__).parent.parent / "test_data"
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+def _blocked_fixture():
+    """2^4 blocked full factorial (16 runs), all-easy continuous factors."""
+    rows = []
+    for i in range(16):
+        bits = [(i >> k) & 1 for k in range(4)]
+        rows.append({
+            "A": 40.0 + 20.0 * bits[0],
+            "B": 80.0 + 40.0 * bits[1],
+            "C": 2.5 + 5.0 * bits[2],
+            "D": 150.0 + 100.0 * bits[3],
+            "Block": 1 + (i % 2),
+        })
+    design = pd.DataFrame(rows)
+    rng = np.random.RandomState(11)
+    a = np.where(design["A"] == 60.0, 1.0, -1.0)
+    b = np.where(design["B"] == 120.0, 1.0, -1.0)
+    c = np.where(design["C"] == 7.5, 1.0, -1.0)
+    d = np.where(design["D"] == 250.0, 1.0, -1.0)
+    block = np.where(design["Block"] == 2, 1.0, -1.0)
+    design["Yield"] = (
+        70.0
+        + 4.0 * a + 3.0 * b - 2.0 * c + 5.0 * d
+        + 2.0 * c * d + 1.5 * block
+        + rng.normal(0.0, 0.4, len(design))
+    )
+    factors = [
+        Factor("A", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[40.0, 60.0]),
+        Factor("B", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[80.0, 120.0]),
+        Factor("C", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[2.5, 7.5]),
+        Factor("D", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[150.0, 250.0]),
+    ]
+    return design, factors
+
+
+def _fit_blocked(model_terms=None):
+    design, factors = _blocked_fixture()
+    analysis = ANOVAAnalysis(
+        design=design, response=design["Yield"].values,
+        factors=factors, response_name="Yield",
+    )
+    terms = model_terms or ["A", "B", "C", "D", "C*D"]
+    return analysis.fit(terms, enforce_hierarchy_flag=False), analysis
+
+
+def _categorical_fixture():
+    """4-level 'numeric-looking' categorical (reference-code meets patsy C())."""
+    levels = [41007587, 41007666, 41005191, 41007741]
+    design = pd.DataFrame({
+        "Cata": pd.Series(levels * 8, dtype="category"),
+        "X": np.tile([10.0, 20.0] * 16, 1),
+        "Block": np.tile([1, 1, 2, 2] * 8, 1),
+    })
+    rng = np.random.RandomState(5)
+    mu = np.array([0.0, 4.0, 7.0, 9.0])
+    design["Yield"] = (
+        100.0
+        + mu[np.array(design["Cata"].cat.codes) % 4]
+        + 2.0 * np.where(design["X"] == 20.0, 1.0, -1.0)
+        + 1.0 * np.where(design["Block"] == 2, 1.0, -1.0)
+        + rng.normal(0.0, 1.0, len(design))
+    )
+    factors = [
+        Factor("Cata", FactorType.CATEGORICAL, ChangeabilityLevel.EASY, levels=levels),
+        Factor("X", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[10.0, 20.0]),
+    ]
+    return design, factors
+
+
+# ---------------------------------------------------------------------------
+# Coefficient-level chart: fitted-model p-values preserved
+# ---------------------------------------------------------------------------
+
+class TestCoefficientSignificance:
+    def test_p_values_match_fitted_model(self):
+        results, _ = _fit_blocked()
+        cs = results.coefficient_significance
+        assert cs is not None and not cs.empty
+        unwrap = {k.replace("C(", "").replace(")", ""): v
+                  for k, v in results.fitted_model.pvalues.items()}
+        for _, row in cs.iterrows():
+            assert row["coefficient_name"] in unwrap, row["coefficient_name"]
+            assert row["p_value"] == pytest.approx(
+                unwrap[row["coefficient_name"]]
+            )
+            assert row["source"] == "Fitted-model coefficient test"
+
+    def test_logworth_formula(self):
+        results, _ = _fit_blocked()
+        cs = results.coefficient_significance
+        for _, row in cs.iterrows():
+            assert row["logworth"] == pytest.approx(
+                coefficient_logworth(row["p_value"])
+            )
+
+    def test_intercept_excluded(self):
+        results, _ = _fit_blocked()
+        names = results.coefficient_significance["coefficient_name"].tolist()
+        assert "Intercept" not in names
+        assert "const" not in names
+
+    def test_block_rows_flagged(self):
+        results, _ = _fit_blocked()
+        cs = results.coefficient_significance
+        block_rows = cs[cs["is_block"].fillna(False)]
+        assert len(block_rows) >= 1
+        assert all("Block" in n for n in block_rows["coefficient_name"])
+
+    def test_preserves_coefficient_and_t(self):
+        results, _ = _fit_blocked()
+        cs = results.coefficient_significance
+        assert cs["coefficient_estimate"].notna().all()
+        assert cs["t_value"].notna().all()
+        assert not cs["p_value"].isna().any()
+
+
+# ---------------------------------------------------------------------------
+# ANOVA-level chart: term-level ANOVA table is source of truth
+# ---------------------------------------------------------------------------
+
+class TestStandardizedEffects:
+    def test_p_values_match_displayed_anova_table(self):
+        results, _ = _fit_blocked()
+        aes = results.anova_effect_summary
+        for term, row in aes.iterrows():
+            anova_row = results.anova_table.loc[term]
+            assert row["p_value"] == pytest.approx(anova_row["PR(>F)"])
+            assert row["source"] == "displayed term-level ANOVA table"
+
+    def test_one_df_t_is_sqrt_F(self):
+        results, _ = _fit_blocked()
+        aes = results.anova_effect_summary
+        for term, row in aes.iterrows():
+            if row["df"] != 1:
+                continue
+            assert row["standardized_statistic_type"] == "|t| = sqrt(F)"
+            assert row["standardized_statistic"] ** 2 == pytest.approx(row["F"])
+
+    def test_residual_df_comes_from_residual_row(self):
+        results, _ = _fit_blocked()
+        aes = results.anova_effect_summary
+        residual_df = results.anova_table.loc["Residual", "df"]
+        assert (aes["residual_df"] == residual_df).all()
+
+    def test_effect_sign_matches_coefficient(self):
+        results, _ = _fit_blocked()
+        aes = results.anova_effect_summary
+        for term, row in aes.iterrows():
+            if row["df"] != 1:
+                continue
+            if np.isnan(row["effect_estimate"]):
+                continue
+            assert row["effect_sign"] == np.sign(row["effect_estimate"])
+
+    def test_critical_limits_bonferroni_stricter(self):
+        results, _ = _fit_blocked()
+        aes = attach_critical_limits(results.anova_effect_summary.copy(), alpha=0.05)
+        finite = aes[aes["t_critical"].notna()]
+        assert not finite.empty
+        assert (finite["bonferroni_limit"] > finite["t_critical"]).all()
+
+    def test_block_bonferroni_policy(self):
+        """Block excluded from the Bonferroni family by default."""
+        assert BONFERRONI_EXCLUDE_BLOCK is True
+        results, _ = _fit_blocked()
+        aes = results.anova_effect_summary
+        assert bool(aes.loc["Block", "is_block"])
+        n_eligible = int(np.sum(~aes["is_block"].astype(bool)))
+        assert n_eligible == len(aes) - 1
+
+
+class TestMultiDfOmnibus:
+    def test_numeric_categorical_is_multi_df(self):
+        design, factors = _categorical_fixture()
+        analysis = ANOVAAnalysis(
+            design=design, response=design["Yield"].values,
+            factors=factors, response_name="Yield",
+        )
+        results = analysis.fit(["Cata", "X"], enforce_hierarchy_flag=False)
+        aes = results.anova_effect_summary
+        assert aes.loc["Cata", "df"] == 3
+        assert aes.loc["Cata", "standardized_statistic_type"] == "omnibus sqrt(F)"
+        assert np.isnan(aes.loc["Cata", "effect_sign"])
+        assert aes.loc["Cata", "standardized_statistic"] ** 2 == pytest.approx(
+            aes.loc["Cata", "F"]
+        )
+
+    def test_dummy_rows_map_to_parent_omnibus_term(self):
+        design, factors = _categorical_fixture()
+        analysis = ANOVAAnalysis(
+            design=design, response=design["Yield"].values,
+            factors=factors, response_name="Yield",
+        )
+        results = analysis.fit(["Cata", "X"], enforce_hierarchy_flag=False)
+        cs = results.coefficient_significance
+        dummies = cs[cs["parent_anova_term"] == "Cata"]
+        assert len(dummies) == 3
+        assert dummies["parent_anova_df"].eq(3).all()
+        assert dummies["coefficient_name"].str.contains("Cata").all()
+
+    def test_anova_p_not_spread_to_dummy_rows(self):
+        """The multi-Df omnibus p never overwrites per-dummy fitted p."""
+        design, factors = _categorical_fixture()
+        analysis = ANOVAAnalysis(
+            design=design, response=design["Yield"].values,
+            factors=factors, response_name="Yield",
+        )
+        results = analysis.fit(["Cata", "X"], enforce_hierarchy_flag=False)
+        omnibus_p = results.anova_table.loc["Cata", "PR(>F)"]
+        cs = results.coefficient_significance
+        dummy_p = cs.loc[cs["parent_anova_term"] == "Cata", "p_value"].values
+        assert (omnibus_p != dummy_p).all()
+
+
+# ---------------------------------------------------------------------------
+# View separation + rendering
+# ---------------------------------------------------------------------------
+
+class TestViewsAndPlots:
+    def test_coefficient_and_anova_views_distinct_sources(self):
+        """Each view carries its own source label; ANOVA never feeds the coeff chart."""
+        design, factors = _categorical_fixture()
+        analysis = ANOVAAnalysis(
+            design=design, response=design["Yield"].values,
+            factors=factors, response_name="Yield",
+        )
+        results = analysis.fit(["Cata", "X"], enforce_hierarchy_flag=False)
+        assert (
+            results.coefficient_significance["source"]
+            == "Fitted-model coefficient test"
+        ).all()
+        assert (
+            results.anova_effect_summary["source"]
+            == "displayed term-level ANOVA table"
+        ).all()
+
+    def test_block_toggle_is_display_only(self):
+        results, _ = _fit_blocked()
+        total_bars = lambda fig: sum(len(t.y) for t in fig.data)
+        full = create_coefficient_significance_plot(results.coefficient_significance)
+        filtered = create_coefficient_significance_plot(
+            results.coefficient_significance, show_block=False
+        )
+        assert total_bars(full) > total_bars(filtered)
+        full_anova = create_standardized_effects_plot(results.anova_effect_summary)
+        filtered_anova = create_standardized_effects_plot(
+            results.anova_effect_summary, show_block=False
+        )
+        assert total_bars(full_anova) > total_bars(filtered_anova)
+
+    def test_uniform_residual_df_gets_critical_lines(self):
+        results, _ = _fit_blocked()
+        fig = create_standardized_effects_plot(results.anova_effect_summary)
+        n_vlines = sum(
+            1 for s in fig.layout.shapes if s.type == "line" and s.xref == "x"
+        )
+        assert n_vlines >= 2
+
+    def test_split_plot_no_universal_critical_line(self):
+        """Split-plot terms use different error strata -> no single critical line."""
+        analysis = ANOVAAnalysis(
+            design=pd.read_csv(DATA_DIR / "test_case_5_split_plot.csv", comment='#'),
+            response=pd.read_csv(
+                DATA_DIR / "test_case_5_split_plot.csv", comment='#'
+            )["Yield"].values,
+            factors=[
+                Factor("Temperature", FactorType.CONTINUOUS, ChangeabilityLevel.HARD,
+                       levels=[125, 175]),
+                Factor("Pressure", FactorType.CONTINUOUS, ChangeabilityLevel.HARD,
+                       levels=[25, 75]),
+                Factor("Time", FactorType.CONTINUOUS, ChangeabilityLevel.EASY,
+                       levels=[0, 20]),
+                Factor("Catalyst", FactorType.CATEGORICAL, ChangeabilityLevel.EASY,
+                       levels=["A", "B"]),
+            ],
+            response_name="Yield",
+        )
+        results = analysis.fit(
+            ["Temperature", "Pressure", "Time", "Catalyst"],
+            enforce_hierarchy_flag=False,
+        )
+        assert results.anova_effect_summary is not None
+        assert results.coefficient_significance is not None
+        assert "Actual_Coefficient" in results.effect_estimates.columns
+        assert "Actual_Std_Error" in results.effect_estimates.columns
+        # Whole-plot and sub-plot terms must carry their own residual DF.
+        wp_df = results.anova_effect_summary.loc["Temperature", "residual_df"]
+        sp_df = results.anova_effect_summary.loc["Time", "residual_df"]
+        assert wp_df != sp_df
+
+    def test_figures_render_for_split_plot(self):
+        analysis = ANOVAAnalysis(
+            design=pd.read_csv(DATA_DIR / "test_case_5_split_plot.csv", comment='#'),
+            response=pd.read_csv(
+                DATA_DIR / "test_case_5_split_plot.csv", comment='#'
+            )["Yield"].values,
+            factors=[
+                Factor("Temperature", FactorType.CONTINUOUS, ChangeabilityLevel.HARD,
+                       levels=[125, 175]),
+                Factor("Pressure", FactorType.CONTINUOUS, ChangeabilityLevel.HARD,
+                       levels=[25, 75]),
+                Factor("Time", FactorType.CONTINUOUS, ChangeabilityLevel.EASY,
+                       levels=[0, 20]),
+                Factor("Catalyst", FactorType.CATEGORICAL, ChangeabilityLevel.EASY,
+                       levels=["A", "B"]),
+            ],
+            response_name="Yield",
+        )
+        results = analysis.fit(
+            ["Temperature", "Pressure", "Time", "Catalyst"],
+            enforce_hierarchy_flag=False,
+        )
+        assert create_coefficient_significance_plot(
+            results.coefficient_significance
+        ) is not None
+        assert create_standardized_effects_plot(
+            results.anova_effect_summary
+        ) is not None

--- a/tests/test_full_factorial.py
+++ b/tests/test_full_factorial.py
@@ -204,6 +204,128 @@ class TestFullFactorial:
         with pytest.raises(ValueError, match="cannot exceed number of runs"):
             full_factorial([temp], n_blocks=n_runs + 1)
 
+    def test_with_replicates(self):
+        """Test factorial with replicates."""
+        temp = Factor("Temperature", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[150, 200])
+        pressure = Factor("Pressure", FactorType.CONTINUOUS,
+                         ChangeabilityLevel.EASY, levels=[50, 100])
+        
+        design = full_factorial([temp, pressure], n_replicates=2, randomize=False)
+        
+        # 4 factorial runs x 2 replicates = 8 runs
+        assert len(design) == 8
+        
+        # Should have a Replicate column
+        assert 'Replicate' in design.columns
+        
+        # Each replicate should appear 4 times
+        replicate_counts = design['Replicate'].value_counts().sort_index()
+        assert list(replicate_counts.index) == [1, 2]
+        assert all(replicate_counts == 4)
+        
+        # Each factor combination should appear exactly twice (once per replicate)
+        combo_counts = design.groupby(['Temperature', 'Pressure']).size()
+        assert all(combo_counts == 2)
+
+    def test_with_replicates_and_center_points(self):
+        """Test factorial with replicates and center points."""
+        temp = Factor("Temperature", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[150, 200])
+        
+        design = full_factorial([temp], n_center_points=2, n_replicates=3, randomize=False)
+        
+        # (2 factorial + 2 center) x 3 replicates = 12 runs
+        assert len(design) == 12
+        
+        # Replicate column present with values 1, 2, 3
+        assert set(design['Replicate'].unique()) == {1, 2, 3}
+        
+        # Each replicate has 4 runs (2 factorial + 2 center)
+        replicate_counts = design['Replicate'].value_counts().sort_index()
+        assert all(replicate_counts == 4)
+
+    def test_replicates_run_order_sequential(self):
+        """Test that RunOrder is sequential across all replicates."""
+        temp = Factor("Temperature", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[150, 200])
+        pressure = Factor("Pressure", FactorType.CONTINUOUS,
+                         ChangeabilityLevel.EASY, levels=[50, 100])
+        
+        design = full_factorial([temp, pressure], n_replicates=3, randomize=False)
+        
+        # RunOrder should be 1 through 12
+        assert list(design['RunOrder']) == list(range(1, 13))
+
+    def test_single_replicate_no_column(self):
+        """Test that n_replicates=1 (default) produces no Replicate column."""
+        temp = Factor("Temperature", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[150, 200])
+        
+        design = full_factorial([temp], randomize=False)
+        
+        assert 'Replicate' not in design.columns
+        assert len(design) == 2
+
+    def test_invalid_replicates_raises_error(self):
+        """Test that n_replicates < 1 raises error."""
+        temp = Factor("Temperature", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[150, 200])
+        
+        with pytest.raises(ValueError, match="Number of replicates"):
+            full_factorial([temp], n_replicates=0)
+
+    def test_with_blocking_and_replicates(self):
+        """Test factorial with both blocking and replicates."""
+        temp = Factor("Temperature", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[150, 200])
+        pressure = Factor("Pressure", FactorType.CONTINUOUS,
+                         ChangeabilityLevel.EASY, levels=[50, 100])
+        
+        design = full_factorial(
+            [temp, pressure], n_replicates=2, n_blocks=2, randomize=False
+        )
+        
+        # 4 factorial points x 2 replicates = 8 runs
+        assert len(design) == 8
+        
+        # Both Replicate and Block columns present
+        assert 'Replicate' in design.columns
+        assert 'Block' in design.columns
+        
+        # 2 replicates, 2 blocks
+        assert set(design['Replicate'].unique()) == {1, 2}
+        assert set(design['Block'].unique()) == {1, 2}
+        
+        # Blocks are balanced: 4 runs each
+        block_counts = design['Block'].value_counts().sort_index()
+        assert all(block_counts == 4)
+
+    def test_blocking_balanced_sizes(self):
+        """Test that blocks are evenly sized."""
+        temp = Factor("Temperature", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[150, 200])
+        pressure = Factor("Pressure", FactorType.CONTINUOUS,
+                         ChangeabilityLevel.EASY, levels=[50, 100])
+        rpm = Factor("RPM", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[100, 200])
+        
+        # 2^3 = 8 runs into 4 blocks = 2 runs each
+        design = full_factorial([temp, pressure, rpm], n_blocks=4, randomize=False)
+        
+        assert 'Block' in design.columns
+        block_sizes = design['Block'].value_counts().sort_index()
+        assert all(block_sizes == 2)
+
+    def test_unblocked_has_no_block_column(self):
+        """Test that default (n_blocks=1) produces no Block column."""
+        temp = Factor("Temperature", FactorType.CONTINUOUS,
+                     ChangeabilityLevel.EASY, levels=[150, 200])
+        
+        design = full_factorial([temp], randomize=False)
+        
+        assert 'Block' not in design.columns
+
 
 class TestDecodeDesign:
     """Test design decoding."""

--- a/tests/test_interaction_plot.py
+++ b/tests/test_interaction_plot.py
@@ -1,0 +1,274 @@
+"""
+Tests for the interaction plot component.
+
+The interaction-plot core lives in ``src.ui.utils.plotting`` as pure,
+testable functions (:func:`interaction_stats` and
+:func:`create_interaction_plot`) so these tests exercise the figure-building
+logic directly without a Streamlit harness, matching the convention used by
+the existing pure plotting helpers.
+
+Edge cases covered:
+- 2x2 designs
+- 4x2 designs (Egg_lot x Egg_percent)
+- categorical factor labels containing numbers (never coerced to numeric)
+- replicated vs non-replicated designs
+- missing response values
+- error-bar modes (mean only / +/- SD / +/- CI)
+- interaction p-value overlay (present, marginal, significant, absent)
+- numeric factor level sorting
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.ui.utils.plotting import (
+    interaction_stats,
+    create_interaction_plot,
+    QUALITATIVE_COLORS,
+    SEQUENTIAL_COLORS,
+)
+from src.core.factors import Factor, FactorType, ChangeabilityLevel
+from src.core.full_factorial import full_factorial
+from src.core.analysis import ANOVAAnalysis
+
+
+class BaseInteractionFixture:
+    """Shared factory helpers for the interaction-plot tests."""
+
+    LOT_LEVELS = ["41007587", "41005191", "41007741", "41007302"]
+
+    @staticmethod
+    def lot_factors():
+        """Categorical Egg_lot (numeric-looking labels) + numeric Egg_percent."""
+        return [
+            Factor(
+                "Egg_lot",
+                FactorType.CATEGORICAL,
+                ChangeabilityLevel.EASY,
+                levels=BaseInteractionFixture.LOT_LEVELS,
+                _validate_on_init=False,
+            ),
+            Factor(
+                "Egg_percent",
+                FactorType.DISCRETE_NUMERIC,
+                ChangeabilityLevel.EASY,
+                levels=[1.2, 1.8],
+            ),
+        ]
+
+    @staticmethod
+    def build_lot_design(n_replicates=2, seed=42):
+        factors = BaseInteractionFixture.lot_factors()
+        design = full_factorial(
+            factors, n_replicates=n_replicates, randomize=False
+        )
+        rng = np.random.default_rng(seed)
+        lot_means = {
+            lot: m
+            for lot, m in zip(
+                BaseInteractionFixture.LOT_LEVELS, [100, 102, 98, 105]
+            )
+        }
+        response = (
+            design["Egg_lot"].map(lot_means).astype(float)
+            + 1.5 * design["Egg_percent"]
+            + rng.normal(0, 0.05, len(design))
+        )
+        return design, np.asarray(response, dtype=float), factors
+
+
+class TestInteractionStats(BaseInteractionFixture):
+    """Aggregation logic."""
+
+    def test_mean_and_n_correct(self):
+        design, response, factors = self.build_lot_design(n_replicates=2)
+        stats = interaction_stats("Egg_lot", "Egg_percent", design, response)
+
+        # 4 lots x 2 percents = 8 combinations, each with 2 replicates.
+        assert len(stats) == 8
+        assert all(stats["n"] == 2)
+
+        # Egg_percent 1.8 should have higher mean than 1.2 for the same lot.
+        p12 = stats[stats["Egg_percent"] == 1.2]
+        p18 = stats[stats["Egg_percent"] == 1.8]
+        assert (p18["mean"].values > p12["mean"].values).all()
+        assert all(stats["std"] > 0)
+        assert all(stats["ci_lower"] < stats["mean"])
+        assert all(stats["mean"] < stats["ci_upper"])
+
+    def test_categorical_levels_stay_strings(self):
+        design, response, factors = self.build_lot_design()
+        stats = interaction_stats("Egg_lot", "Egg_percent", design, response)
+        assert all(isinstance(v, str) for v in stats["Egg_lot"])
+
+    def test_non_replicated_collapses_spread(self):
+        design, response, factors = self.build_lot_design(n_replicates=1)
+        # Deterministic response -> identical means within a combo.
+        lot_means = {lot: m for lot, m in
+                     zip(self.LOT_LEVELS, [100, 102, 98, 105])}
+        response = (
+            design["Egg_lot"].map(lot_means).astype(float)
+            + 1.5 * design["Egg_percent"]
+        )
+        stats = interaction_stats("Egg_lot", "Egg_percent", design, response)
+        assert all(stats["n"] == 1)
+        assert all(stats["std"] == 0.0)
+        assert all(stats["sem"] == 0.0)
+        assert np.allclose(stats["ci_lower"], stats["mean"])
+        assert np.allclose(stats["ci_upper"], stats["mean"])
+
+    def test_missing_response_drops_row(self):
+        design, response, factors = self.build_lot_design(n_replicates=2)
+        # Null one replicate of the first run.
+        response = response.copy()
+        response[0] = np.nan
+        stats = interaction_stats("Egg_lot", "Egg_percent", design, response)
+
+        # The affected combo has n==1 remaining; all other combos keep n==2.
+        assert len(stats) == 8
+        dropped_lot = design["Egg_lot"].iloc[0]
+        dropped_percent = design["Egg_percent"].iloc[0]
+        affected = stats[
+            (stats["Egg_lot"] == str(dropped_lot))
+            & (stats["Egg_percent"] == dropped_percent)
+        ].iloc[0]
+        assert affected["n"] == 1
+        # No NaN means anywhere.
+        assert not stats["mean"].isna().any()
+
+
+class TestCreateInteractionPlot(BaseInteractionFixture):
+    """Figure-building behaviour."""
+
+    def _fig(self, **kwargs):
+        design, response, factors = self.build_lot_design()
+        stats = interaction_stats("Egg_lot", "Egg_percent", design, response)
+        default = {
+            "stats": stats,
+            "f1_name": "Egg_lot",
+            "f2_name": "Egg_percent",
+            "f1_is_categorical": True,
+            "f2_is_categorical": False,
+            "response_name": "Day_7_Max_Force",
+        }
+        default.update(kwargs)
+        return create_interaction_plot(**default), stats
+
+    def test_numeric_line_factor_has_sequential_palette(self):
+        fig, _ = self._fig()
+        # Egg_lot on x (categorical) -> category axis.
+        assert fig.layout.xaxis.type == "category"
+        assert len(fig.data) == 2  # two Egg_percent levels
+        assert fig.data[0].line.color == SEQUENTIAL_COLORS[0]
+        assert fig.data[1].line.color == SEQUENTIAL_COLORS[-1]
+
+    def test_categorical_line_factor_has_qualitative_palette(self):
+        fig, stats = self._fig(
+            f1_name="Egg_percent",
+            f2_name="Egg_lot",
+            f1_is_categorical=False,
+            f2_is_categorical=True,
+        )
+        assert fig.layout.xaxis.type == "linear"
+        # Four lot levels -> four lines, coloured from the qualitative palette.
+        assert len(fig.data) == 4
+        colors = [t.line.color for t in fig.data]
+        assert colors == QUALITATIVE_COLORS[:4]
+
+    def test_numeric_x_levels_sorted(self):
+        fig, _ = self._fig(
+            f1_name="Egg_percent",
+            f2_name="Egg_lot",
+            f1_is_categorical=False,
+            f2_is_categorical=True,
+        )
+        xs = list(fig.data[0].x)
+        assert xs == sorted(xs)
+
+    def test_error_mode_none_has_no_error_bars(self):
+        fig, _ = self._fig(error_mode="none")
+        for t in fig.data:
+            # Plotly materialises an empty error_y object when unset.
+            assert len(t.error_y.to_plotly_json()) == 0
+
+    def test_error_mode_sd_sets_error_y(self):
+        fig, _ = self._fig(error_mode="sd")
+        for t in fig.data:
+            assert "array" in t.error_y.to_plotly_json()
+
+    def test_error_mode_ci_sets_error_y(self):
+        fig, _ = self._fig(error_mode="ci")
+        for t in fig.data:
+            assert "array" in t.error_y.to_plotly_json()
+
+    def test_interaction_significant_subtitle(self):
+        fig, _ = self._fig(p_value=0.012)
+        sub = fig.layout.title.subtitle.text
+        assert "Significant interaction" in sub
+        assert "0.012" in sub
+
+    def test_interaction_marginal_subtitle(self):
+        fig, _ = self._fig(p_value=0.07)
+        assert "Marginal interaction" in fig.layout.title.subtitle.text
+
+    def test_interaction_not_significant_subtitle(self):
+        fig, _ = self._fig(p_value=0.5)
+        assert "No significant interaction" in fig.layout.title.subtitle.text
+
+    def test_interaction_absent_marks_not_in_model(self):
+        fig, _ = self._fig(interaction_present=False)
+        assert "not in model" in fig.layout.title.subtitle.text
+
+    def test_tooltip_includes_sd_and_n(self):
+        fig, _ = self._fig()
+        tmpl = fig.data[0].hovertemplate
+        assert "SD:" in tmpl and "n:" in tmpl and "Day_7_Max_Force:" in tmpl
+        # The x-labels appear in the tooltip.
+        assert "Egg_lot:" in tmpl and "Egg_percent:" in tmpl
+
+    def test_2x2_design(self):
+        factors = [
+            Factor("A", FactorType.CATEGORICAL, ChangeabilityLevel.EASY,
+                   levels=["a", "b"]),
+            Factor("B", FactorType.CATEGORICAL, ChangeabilityLevel.EASY,
+                   levels=["x", "y"]),
+        ]
+        design = full_factorial(factors, randomize=False)
+        response = np.array([10.0, 20.0, 12.0, 22.0])
+        stats = interaction_stats("A", "B", design, response)
+        assert len(stats) == 4
+        fig = create_interaction_plot(
+            stats, "A", "B", True, True, "Resp"
+        )
+        assert len(fig.data) == 2  # two B levels
+        assert fig.layout.xaxis.type == "category"
+
+
+class TestIntegrationWithANOVA(BaseInteractionFixture):
+    """End-to-end: fit ANOVA, read interaction p-value, build plot."""
+
+    def test_pvalue_extracted_from_fitted_model(self):
+        design, response, factors = self.build_lot_design()
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(
+            ["Egg_lot", "Egg_percent", "Egg_lot*Egg_percent"]
+        )
+
+        key = "Egg_lot:Egg_percent"
+        col = "PR(>F)" if "PR(>F)" in results.anova_table.columns else "P"
+        p_value = float(results.anova_table.loc[key, col])
+        assert 0.0 < p_value < 1.0
+
+        stats = interaction_stats("Egg_lot", "Egg_percent", design, response)
+        fig = create_interaction_plot(
+            stats,
+            "Egg_lot",
+            "Egg_percent",
+            True,
+            False,
+            "Day_7_Max_Force",
+            p_value=p_value,
+            interaction_present=True,
+        )
+        assert "interaction p-value" in fig.layout.title.subtitle.text

--- a/tests/test_interaction_plot.py
+++ b/tests/test_interaction_plot.py
@@ -244,6 +244,48 @@ class TestCreateInteractionPlot(BaseInteractionFixture):
         assert len(fig.data) == 2  # two B levels
         assert fig.layout.xaxis.type == "category"
 
+    def test_integer_numeric_factors_render_lines(self):
+        """Integer-valued discrete-numeric factors must draw visible lines.
+
+        Regression: ``_sorted_levels`` returned floats (1.0, 2.0) while the
+        stats columns were stringified from the original ints ('1', '2'),
+        so ``str(1.0)`` never matched '1' and every y-value was None.
+        """
+        factors = [
+            Factor("Temperature", FactorType.DISCRETE_NUMERIC,
+                   ChangeabilityLevel.EASY, levels=[70, 80]),
+            Factor("Catalyst", FactorType.DISCRETE_NUMERIC,
+                   ChangeabilityLevel.EASY, levels=[1, 2]),
+        ]
+        design = full_factorial(factors, n_replicates=2, randomize=False)
+        # Deterministic response: each temperature/catalyst combo distinct.
+        response = np.array(
+            [10.0, 12.0, 16.0, 18.0] * 2, dtype=float
+        )
+        assert design["Catalyst"].dtype.kind in "iu"  # integer column
+
+        stats = interaction_stats("Temperature", "Catalyst", design, response)
+        assert len(stats) == 4  # 2 temperatures x 2 catalysts
+
+        # Catalyst on the x-axis (integer numeric): lines drawn, not empty.
+        fig = create_interaction_plot(
+            stats, "Catalyst", "Temperature", False, False, "Yield"
+        )
+        assert len(fig.data) == 2
+        ys = sorted(tuple(t.y) for t in fig.data)
+        assert ys == [(10.0, 12.0), (16.0, 18.0)]
+        assert fig.layout.xaxis.type == "linear"
+        assert list(fig.data[0].x) == [1.0, 2.0]
+
+        # Temperature on the x-axis (integer numeric): lines drawn too.
+        fig2 = create_interaction_plot(
+            stats, "Temperature", "Catalyst", False, False, "Yield"
+        )
+        assert len(fig2.data) == 2
+        ys2 = sorted(tuple(t.y) for t in fig2.data)
+        assert ys2 == [(10.0, 16.0), (12.0, 18.0)]
+        assert list(fig2.data[0].x) == [70.0, 80.0]
+
 
 class TestIntegrationWithANOVA(BaseInteractionFixture):
     """End-to-end: fit ANOVA, read interaction p-value, build plot."""

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -23,7 +23,9 @@ from src.core.optimization import (
     desirability_maximize,
     desirability_minimize,
     desirability_target,
-    predict_with_intervals
+    predict_with_intervals,
+    _nuisance_columns_for_model,
+    _nearest_level,
 )
 from src.core.optimal.constraints import LinearConstraint
 from src.core.analysis import ANOVAAnalysis, ANOVAResults
@@ -918,3 +920,158 @@ class TestCategoricalFactors:
             assert frame["Catalyst"].iloc[0] == (
                 "A" if idx == 0 else "B"
             )
+
+
+class TestBlockedDesignOptimization:
+    """Optimization on blocked designs must ignore the Block nuisance term.
+
+    Regression: a blocked design appends ' + Block' to the model formula, but
+    the optimizer's prediction frame omitted the Block column, crashing patsy
+    with 'NameError: name Block is not defined'. Block is not optimizable, so
+    it is pinned to its reference (first) level and its effect ignored.
+    """
+
+    def _blocked_fit(self):
+        factors = [
+            Factor("A", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[-1, 1]),
+            Factor("B", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[-1, 1])
+        ]
+        # Each run replicated introduces error df so the model is not saturated.
+        design = full_factorial(factors, n_blocks=2, randomize=False, n_replicates=2)
+        # Block effect: block 2 shifts the response by +10.
+        response = 10 + 2 * design["A"] + 3 * design["B"] + 10 * (design["Block"] - 1)
+        analysis = ANOVAAnalysis(design, response, factors, block_as_random=False)
+        results = analysis.fit(["A", "B"])
+        return factors, design, results
+
+    def test_nuisance_columns_detect_block_reference_level(self):
+        factors, _, results = self._blocked_fit()
+        extra = _nuisance_columns_for_model(results.fitted_model, factors)
+        # Block is cast to str during fit (analysis.py), so reference level is '1'.
+        assert extra == {"Block": "1"}
+
+    def test_optimize_response_ignores_block(self):
+        factors, design, results = self._blocked_fit()
+        opt = optimize_response(
+            anova_results=results, factors=factors, objective="maximize", seed=42
+        )
+        assert opt.success
+        assert opt.prediction_interval is not None
+        # The optimum must match a direct prediction at the reference Block='1',
+        # i.e. the block-2 shift (+10) is ignored.
+        settings = opt.optimal_settings
+        ref = results.fitted_model.predict(
+            pd.DataFrame([{
+                "Block": "1",
+                "A": settings["A"],
+                "B": settings["B"],
+            }])
+        )[0]
+        assert opt.predicted_response == pytest.approx(float(ref), rel=1e-6)
+        # And it should NOT equal the same settings predicted in block 2.
+        blk2 = results.fitted_model.predict(
+            pd.DataFrame([{
+                "Block": "2",
+                "A": settings["A"],
+                "B": settings["B"],
+            }])
+        )[0]
+        assert blk2 != pytest.approx(float(ref), abs=0.1)
+
+    def test_optimize_desirability_ignores_block(self):
+        factors, _, results = self._blocked_fit()
+        df = DesirabilityFunction(["Yield"])
+        df.add_response("Yield", "maximize", low=10, high=20)
+        dopt = optimize_desirability(
+            {"Yield": results}, factors, df, seed=42
+        )
+        assert dopt.success
+        # Predicted response at optimum equals reference-block prediction.
+        settings = dopt.optimal_settings
+        ref = results.fitted_model.predict(
+            pd.DataFrame([{
+                "Block": "1",
+                "A": settings["A"],
+                "B": settings["B"],
+            }])
+        )[0]
+        assert dopt.predicted_responses["Yield"] == pytest.approx(float(ref), rel=1e-6)
+
+
+class TestNearestLevel:
+    """_nearest_level('...') must snap a real value to a declared level."""
+
+    def test_exact_level(self):
+        assert _nearest_level(1.2, [1.2, 1.8]) == 1.2
+        assert _nearest_level(1.8, [1.2, 1.8]) == 1.8
+
+    def test_midpoint_rounds_to_lower(self):
+        # Midway between 1.2 and 1.8 -> min() picks the first (1.2).
+        assert _nearest_level(1.5, [1.2, 1.8]) == 1.2
+
+    def test_out_of_range_clamped_to_nearest_level(self):
+        assert _nearest_level(-50.0, [1.2, 1.8]) == 1.2
+        assert _nearest_level(99.0, [1.2, 1.8]) == 1.8
+
+    def test_integer_levels(self):
+        assert _nearest_level(23, [10, 20, 30]) == 20
+
+
+class TestDiscreteNumericOptimization:
+    """Discrete_numeric factors must be optimizable and snap to declared levels.
+
+    Regression: the Optimize page listed only factors matching its
+    continuous/categorical branches, so a discrete_numeric factor such as
+    Egg_percent was invisible. The backend also optimized discrete factors to
+    off-grid real values instead of their declared levels.
+    """
+
+    def _discrete_fit(self):
+        factors = [
+            Factor("T", FactorType.CONTINUOUS, ChangeabilityLevel.EASY, levels=[-1, 1]),
+            Factor("D", FactorType.DISCRETE_NUMERIC, ChangeabilityLevel.EASY, levels=[1.2, 1.8]),
+        ]
+        design = full_factorial(factors, randomize=False, random_seed=1)
+        # Response rises with both factors; optimum at T=+1, D=1.8.
+        response = 10 + 2 * design["T"] + 5 * design["D"]
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(["1", "T", "D"])
+        return factors, design, results
+
+    def test_optimize_response_snaps_discrete_to_declared_level(self):
+        factors, _, results = self._discrete_fit()
+        opt = optimize_response(
+            anova_results=results, factors=factors, objective="maximize", seed=42
+        )
+        assert opt.success
+        assert opt.optimal_settings["D"] in (1.2, 1.8)
+        assert opt.prediction_interval is not None
+        # Prediction must be self-consistent with the reported (snapped) settings.
+        s = opt.optimal_settings
+        ref = results.fitted_model.predict(
+            pd.DataFrame([{"T": s["T"], "D": s["D"]}])
+        )[0]
+        assert opt.predicted_response == pytest.approx(float(ref), rel=1e-6)
+
+    def test_optimize_response_respects_discrete_bounds(self):
+        factors, _, results = self._discrete_fit()
+        opt = optimize_response(
+            anova_results=results,
+            factors=factors,
+            objective="maximize",
+            bounds={"D": (1.2, 1.2)},
+            seed=42,
+        )
+        assert opt.success
+        # Pinned bound to a single level must force that level.
+        assert opt.optimal_settings["D"] == 1.2
+
+    def test_optimize_desirability_snaps_discrete_to_declared_level(self):
+        factors, _, results = self._discrete_fit()
+        d = DesirabilityFunction(["Y"])
+        d.add_response("Y", "maximize", low=5, high=25)
+        dopt = optimize_desirability(
+            {"Y": results}, factors, d, seed=42
+        )
+        assert dopt.success
+        assert dopt.optimal_settings["D"] in (1.2, 1.8)

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -15,6 +15,7 @@ import pandas as pd
 from unittest.mock import Mock
 
 from src.core.factors import Factor, FactorType, ChangeabilityLevel
+from src.core.full_factorial import full_factorial
 from src.core.optimization import (
     optimize_response,
     optimize_desirability,
@@ -825,3 +826,95 @@ class TestEdgeCases:
         
         with pytest.raises(ValueError, match="No model provided"):
             optimize_desirability(models, simple_factors, df)
+
+
+class TestCategoricalFactors:
+    """Optimization over mixed continuous + categorical designs."""
+
+    @staticmethod
+    def _mixed_design(seed=7):
+        """Full factorial x Continuous X1 + categorical Catalyst with a strong
+        level effect.  Catalyst 'B' is far better than 'A'."""
+        x1 = Factor("X1", FactorType.CONTINUOUS, ChangeabilityLevel.EASY,
+                    levels=[-1, 1])
+        catalyst = Factor("Catalyst", FactorType.CATEGORICAL,
+                          ChangeabilityLevel.EASY, levels=["A", "B"])
+        factors = [x1, catalyst]
+        design = full_factorial(factors, n_replicates=3, randomize=False)
+
+        rng = np.random.default_rng(seed)
+        # X1 raises response by +2 per coded unit; Catalyst B adds +10.
+        base_a = design["X1"].astype(float) * 2.0
+        level_b = (design["Catalyst"] == "B").astype(float) * 10.0
+        response = np.asarray(5.0 + base_a + level_b, dtype=float).copy()
+        response += rng.normal(0, 0.05, len(response))
+        return factors, design, response
+
+    def test_single_response_chooses_best_categorical_level(self):
+        factors, design, response = self._mixed_design()
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(["X1", "Catalyst", "X1*Catalyst"])
+
+        opt = optimize_response(
+            results, factors, objective="maximize", seed=1
+        )
+        assert opt.success
+
+        settings = opt.optimal_settings
+        # Catalyst B is strictly better (+10), so it must be chosen.
+        assert settings["Catalyst"] == "B"
+        # X1 maxed out (+1) for maximize.
+        assert settings["X1"] == pytest.approx(1, abs=0.2)
+        # Predicted response near the optimum of the linear model.
+        assert opt.predicted_response == pytest.approx(17, abs=0.5)
+
+    def test_single_response_respects_pinned_level(self):
+        factors, design, response = self._mixed_design()
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(["X1", "Catalyst", "X1*Catalyst"])
+
+        opt = optimize_response(
+            results, factors, objective="maximize", seed=1,
+            pinned_levels={"Catalyst": "A"},
+        )
+        assert opt.success
+        assert opt.optimal_settings["Catalyst"] == "A"
+        assert opt.optimal_settings["X1"] == pytest.approx(1, abs=0.2)
+        # With Catalyst A the linear optimum is 5 + 2 = 7.
+        assert opt.predicted_response == pytest.approx(7, abs=0.5)
+
+    def test_invalid_pinned_level_raises(self):
+        factors, design, response = self._mixed_design()
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(["X1", "Catalyst", "X1*Catalyst"])
+        with pytest.raises(ValueError, match="not a valid level"):
+            optimize_response(
+                results, factors, objective="maximize", seed=1,
+                pinned_levels={"Catalyst": "Z"},
+            )
+
+    def test_desirability_over_mixed_design(self):
+        factors, design, response = self._mixed_design()
+        analysis = ANOVAAnalysis(design, response, factors)
+        results = analysis.fit(["X1", "Catalyst", "X1*Catalyst"])
+
+        df = DesirabilityFunction(["Yield"])
+        df.add_response("Yield", "maximize", low=5, high=20)
+
+        dopt = optimize_desirability(
+            {"Yield": results}, factors, df, seed=1
+        )
+        assert dopt.success
+        assert dopt.optimal_settings["Catalyst"] == "B"
+        assert dopt.optimal_settings["X1"] == pytest.approx(1, abs=0.2)
+
+    def test_prediction_frame_hold_categoricals(self):
+        """to_prediction_frame returns labels, not raw indices."""
+        factors, _, _ = self._mixed_design()
+        from src.core.optimization import _OptimizationDims
+        dims = _OptimizationDims(factors)
+        for idx in (0, 1):
+            frame = dims.to_prediction_frame(np.array([0.0, float(idx)]))
+            assert frame["Catalyst"].iloc[0] == (
+                "A" if idx == 0 else "B"
+            )

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -229,7 +229,7 @@ class TestDesirabilityFunctions:
         # At upper bound
         assert desirability_maximize(20, 10, 20) == 1.0
         
-        # Above range
+        # Above range (saturates at d=1 — standard Derringer-Suich)
         assert desirability_maximize(25, 10, 20) == 1.0
     
     def test_desirability_maximize_weight(self):
@@ -244,8 +244,8 @@ class TestDesirabilityFunctions:
     
     def test_desirability_minimize_basic(self):
         """Test minimize desirability."""
-        assert desirability_minimize(5, 10, 20) == 1.0   # Below range
-        assert desirability_minimize(10, 10, 20) == 1.0  # At target
+        assert desirability_minimize(5, 10, 20) == 1.0   # Below range (saturates at d=1)
+        assert desirability_minimize(10, 10, 20) == 1.0  # At ideal
         assert desirability_minimize(15, 10, 20) == pytest.approx(0.5)
         assert desirability_minimize(20, 10, 20) == 0.0  # At max
         assert desirability_minimize(25, 10, 20) == 0.0  # Above range


### PR DESCRIPTION
# PR Plan: Improve Optimize Page — Desirability Mode Visibility & Functionality

**Branch:** `optimize-page-changes`

## Problem

The Desirability Function configuration on the Optimize page is hard to find (it was behind a sidebar toggle), responses are shown out of CSV column order, there's no "None" goal option for tracking-only responses, there's no guidance that responses must be fitted in Step 6 first, and the desirability Lower/Upper limits were interpreted as **soft** targets rather than **hard** constraints.

## Changes

### 1. Response ordering: use CSV column order

The desirability page now iterates responses in CSV column order (`st.session_state['response_names']`) instead of `fitted_models` insertion order (which depends on the sequence the user fitted them in Step 6).

```python
# Before
response_names = list(fitted_models.keys())

# After
all_response_names = st.session_state.get('response_names', [])
response_names = [rn for rn in all_response_names if rn in fitted_models]
```

### 2. Move mode selector from sidebar to below the page title

Previously the mode selector ("Single Response" / "Desirability Function") and the response dropdown lived in the sidebar. When only one response was fitted the sidebar showed only static text with no interactive selector, which confused users. The selector is now rendered directly below the page title.

- Single fitted response → single-response mode used automatically.
- Multiple fitted responses → a radio (`Single Response` / `Desirability Function`) plus a response dropdown appear under the title.

### 3. Move per-response configuration to the top of the page

The per-response Goal/Importance/Low/High/Weight expanders are moved from inside the "Multi-Response Optimization" tab to the top of the page — right after the title and info box. This makes them immediately visible without needing to find the correct tab.

Layout after the change:

```
Title: Step 7: Response Optimization
Mode selector (radio + response dropdown)
Info box (updated text)
─── Per-response configuration expanders (MOVED HERE) ───
  Configure: Response A  [Goal: None ▼] [Importance: 3] [Low] [High] [Weight]
  Configure: Response B  [Goal: Maximize ▼] [Importance: 3] [Low] [High] [Weight]
  ...
  Note about unfitted responses
─── Tabs ───
  Tab 1: Factor Bounds + Find Optimal Settings + Results
  Tab 2: Desirability Profile
```

### 4. Add "None" goal option (default)

A new "None" option is added to the Goal dropdown for each response. When Goal == "None":

- The response is **excluded** from the desirability D calculation (does not affect optimization)
- The response is still **predicted** at optimal settings and shown in results
- Low/High/Weight fields are still visible (matching Design Expert's layout)
- In results, desirability shows as "—" for None responses

This matches Design Expert behavior where "none" means "track but don't optimize."

### 5. Updated info box text

The blue info box now explains:
- Only responses fitted in Step 6 (Analyze) appear here
- Responses are in CSV column order
- Goal "None" tracks without optimizing

### 6. Unfitted response note

A note is shown listing any responses from the CSV that have NOT been fitted yet, with guidance to go to Step 6:

```
⚠️ Not yet analyzed (go to Step 6 to fit): Response C, Response D
```

### 7. DesirabilityFunction: skip "None" responses

Only responses with Goal != "None" are added to the `DesirabilityFunction` object. All fitted models are still passed to the optimizer (so it can predict all responses), but the D calculation only includes active goals.

### 8. Results display: mark "None" with "—

In the predicted responses table, "None" responses show their predicted value but "—" for desirability and importance.

### 9. Desirability Profile: exclude "None" from bar chart

The bar chart only shows responses with actual desirability values. "None" responses appear in the summary table but not the chart.

### 10. Desirability bounds: standard Derringer & Suich semantics (REVISED)

**History:** An initial attempt implemented hard ceiling/floor semantics (d=0 for values beyond the limit). This was reverted because it breaks the optimizer: when any individual d_i=0, the geometric mean D=0 everywhere, creating a flat objective with no gradient signal. Differential evolution (and any gradient-based solver) cannot navigate this landscape.

**Current behavior** (standard Derringer & Suich, 1980):

- **Maximize — High (d=1) is the ideal value.** Values at or above it get `d=1` (fully satisfactory). Values below ramp from `d=0` at Low to `d=1` at High.
- **Minimize — Low (d=1) is the ideal value.** Values at or below it get `d=1` (fully satisfactory). Values above ramp from `d=1` at Low to `d=0` at High.

This matches Design Expert's behavior: the limits express preferences (where d=0 and d=1), not absolute ceilings/floors. Values beyond the ideal are *tolerated* (d=1), giving the optimizer a smooth objective to navigate when responses conflict.

**Solver change:** `optimize_desirability` now always uses `differential_evolution` (global gradient-free) instead of SLSQP (local gradient-based). This is more robust for multi-modal desirability landscapes and handles the categorical fallback uniformly.

```python
def desirability_maximize(y, low, high, weight=1.0):
    if y < low:
        return 0.0
    elif y >= high:       # saturates at d=1 — standard Derringer-Suich
        return 1.0
    else:
        return ((y - low) / (high - low)) ** weight

def desirability_minimize(y, low, high, weight=1.0):
    if y <= low:          # saturates at d=1 — standard Derringer-Suich
        return 1.0
    elif y > high:
        return 0.0
    else:
        return ((high - y) / (high - low)) ** weight
```

### 11. Auto-populated Limit defaults

The Lower/Upper Limit fields default to the **measured min/max** of each response (`st.session_state['responses']`) rather than the previous hardcoded 0/1. This makes the desirability ramp meaningful from the start (previously a response scaled in the hundreds with default limits of 0/1 produced a flat `d=1` everywhere, so the optimizer just stayed at the center point). The limits remain user-editable.

### 12. Guard against nothing-to-optimize (all "None")

If every response is set to "None", the optimizer has no objective. The UI now shows a clear error ("Set at least one response to Maximize, Minimize, or Target...") and disables the run button; the backend also raises a descriptive error via `optimize_desirability`.

### 13. "None" responses no longer crash the optimizer

`optimize_desirability` previously iterated ALL fitted models and called `evaluate_individual()` for each — including "None" responses that weren't configured, raising `ValueError: Response ... not configured`. It now only evaluates desirability for responses actually in the `DesirabilityFunction`, while still predicting all responses for the results table.

## Files Modified

| File | Change |
|---|---|
| `src/ui/pages/8_optimize.py` | Mode selector below title; response ordering; config moved to top; "None" goal; info box; unfitted note; auto-populated limits; all-"None" guard; results "—" for None |
| `src/core/optimization.py` | Standard Derringer-Suich desirability bounds (soft); `differential_evolution` for all desirability optimization; skip "None" in post-optimization loop; all-"None" guard in `optimize_desirability` |
| `tests/test_optimization.py` | Updated tests that encoded the old soft high/low behavior |

## Verification

- `python -m pytest tests/ --ignore=tests/test_constraint_ui.py -q` — must maintain the 60-failure baseline (with affected desirability tests updated, not newly broken)
- Manual: import multi-response CSV → Optimize page shows all fitted responses in CSV order, expanders at top, selector below title
- Manual: set Goal="None" for a response → optimize → predicted but no desirability in results
- Manual: unfitted responses listed in note with guidance
- Manual: set a Maximize response's Upper Limit low → the predicted value must never exceed the limit
- Manual: set a Minimize response's Lower Limit high → the predicted value must never go below the limit